### PR TITLE
Separated out event consumers to allow independant consumption of events. Added event, task, stage and job progress

### DIFF
--- a/src/main/scala/com/groupon/sparklint/SparklintListener.scala
+++ b/src/main/scala/com/groupon/sparklint/SparklintListener.scala
@@ -24,24 +24,36 @@ import org.apache.spark.{SparkConf, SparkFirehoseListener}
   * @since 8/18/16.
   */
 class SparklintListener(appId: String, appName: String) extends SparkFirehoseListener {
+
   def this(conf: SparkConf) = {
     this(conf.get("spark.app.id", "AppId"), conf.get("spark.app.name", "AppName"))
   }
 
-  private val progressReceiver = EventSourceProgress()
-  private val stateReceiver = new CompressedEventState()
-  private val eventSource   = BufferedEventSource(appId, Seq(progressReceiver, stateReceiver))
-  private val sourceManager = new EventSourceManager(EventSourceDetail(eventSource, progressReceiver, stateReceiver))
-
-  val scheduler = new Scheduler()
-  val config    = SparklintConfig()
-  val server    = new SparklintServer(sourceManager, scheduler, config)
-  server.run()
-
-  eventSource.runnit()
-
   override def onEvent(event: SparkListenerEvent): Unit = {
     // push unconsumed events to the queue so the listener can keep consuming on the main thread
-    eventSource.push(event)
+    buffer.push(event)
   }
+
+  private val factory                     = new ListenerEventSourceFactory()
+  private val sourceManager               = new EventSourceManager()
+  private val eventSource                 = factory.buildEventSourceDetail(appId) match {
+    case Some(detail) => startListening(detail)
+    case None         => throw new Exception(s"Unable to construct buffered source from $appId:$appName")
+  }
+  private var buffer: BufferedEventSource = _
+
+  private def startListening(detail: EventSourceDetail) = detail.source match {
+    case bufferedSource: BufferedEventSource => setAndRun(bufferedSource)
+    case _                                   => throw new Exception("Created EventSource cannot act as a buffer")
+  }
+
+  private def setAndRun(bufferedSource: BufferedEventSource) = {
+    buffer = bufferedSource
+    val scheduler = new Scheduler()
+    val config = SparklintConfig()
+    val server = new SparklintServer(sourceManager, scheduler, config)
+    server.run()
+  }
+
+
 }

--- a/src/main/scala/com/groupon/sparklint/SparklintListener.scala
+++ b/src/main/scala/com/groupon/sparklint/SparklintListener.scala
@@ -12,8 +12,8 @@
 */
 package com.groupon.sparklint
 
-import com.groupon.sparklint.common.{SparklintConfig, Scheduler}
-import com.groupon.sparklint.events.{BufferedEventSource, CompressedEventState, EventSourceManager}
+import com.groupon.sparklint.common.{Scheduler, SparklintConfig}
+import com.groupon.sparklint.events._
 import org.apache.spark.scheduler.SparkListenerEvent
 import org.apache.spark.{SparkConf, SparkFirehoseListener}
 
@@ -28,8 +28,10 @@ class SparklintListener(appId: String, appName: String) extends SparkFirehoseLis
     this(conf.get("spark.app.id", "AppId"), conf.get("spark.app.name", "AppName"))
   }
 
-  private val eventSource   = BufferedEventSource(appId, new CompressedEventState())
-  private val sourceManager = new EventSourceManager(eventSource)
+  private val progressReceiver = EventSourceProgress()
+  private val stateReceiver = new CompressedEventState()
+  private val eventSource   = BufferedEventSource(appId, Seq(progressReceiver, stateReceiver))
+  private val sourceManager = new EventSourceManager(EventSourceDetail(eventSource, progressReceiver, stateReceiver))
 
   val scheduler = new Scheduler()
   val config    = SparklintConfig()

--- a/src/main/scala/com/groupon/sparklint/common/Logging.scala
+++ b/src/main/scala/com/groupon/sparklint/common/Logging.scala
@@ -35,6 +35,10 @@ trait Logging {
     log.error(message)
   }
 
+  def logError(message: String, ex: Throwable): Unit = {
+    log.error(message, ex)
+  }
+
   def logWarn(message: String): Unit = {
     log.warn(message)
   }

--- a/src/main/scala/com/groupon/sparklint/common/Scheduler.scala
+++ b/src/main/scala/com/groupon/sparklint/common/Scheduler.scala
@@ -14,6 +14,10 @@ package com.groupon.sparklint.common
 
 import java.util.{Timer, TimerTask}
 
+import org.apache.commons.lang3.exception.ExceptionUtils
+
+import scala.util.{Failure, Success, Try}
+
 /**
   * A way of scheduling tasks to run on timers. Not intended as a high resolution component,
   * hence the use of multi-second period and delays.
@@ -50,9 +54,11 @@ case class ScheduledTask[T](name: String, context: T, fn: (T) => Unit,
                            (implicit logger: Logging)
   extends TimerTask {
 
-  override def run(): Unit = {
+  override def run(): Unit = Try({
     logger.logInfo(s"Executing ScheduledTask $name.")
     fn(context)
-    logger.logInfo(s"Execution of $name completed with state $context")
+  }) match {
+    case Success(_) => logger.logInfo(s"Execution of $name completed with state $context")
+    case Failure(ex) => logger.logError(s"Execution of $name failed with exception.", ex)
   }
 }

--- a/src/main/scala/com/groupon/sparklint/events/BufferedEventSource.scala
+++ b/src/main/scala/com/groupon/sparklint/events/BufferedEventSource.scala
@@ -20,12 +20,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 /**
-  *
+  * An EventSource that uses an intermediary queue to buffer live events before updating receivers.
   * @author swhitear 
   * @since 8/18/16.
   */
 case class BufferedEventSource(appId: String, receivers: Seq[EventReceiverLike])
-  extends EventSourceBase() with EventSourceLike {
+  extends EventSourceBase {
 
   val buffer: BlockingQueue[SparkListenerEvent] = new LinkedBlockingDeque()
 
@@ -35,7 +35,7 @@ case class BufferedEventSource(appId: String, receivers: Seq[EventReceiverLike])
 
   private var processed: Int = 0
 
-  def runnit() = Future {
+  def startConsuming() = Future {
     while (true) {
       val event = buffer.take()
       receivers.foreach(r => {

--- a/src/main/scala/com/groupon/sparklint/events/CompressedEventState.scala
+++ b/src/main/scala/com/groupon/sparklint/events/CompressedEventState.scala
@@ -21,7 +21,7 @@ import org.apache.spark.scheduler._
   * @author rxue
   * @since 9/7/16.
   */
-class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike with EventReceiverLike {
+class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
   // collections will be optimized for fast writes
   // snapshoting will enable the analyzer to capture the raw data and run models against it
   var state: CompressedState = CompressedState.empty

--- a/src/main/scala/com/groupon/sparklint/events/CompressedEventState.scala
+++ b/src/main/scala/com/groupon/sparklint/events/CompressedEventState.scala
@@ -18,104 +18,67 @@ import com.groupon.sparklint.data.compressed._
 import org.apache.spark.scheduler._
 
 /**
-  *
-  * @author swhitear 
+  * @author rxue
   * @since 9/7/16.
   */
-class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
+class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike with EventReceiverLike {
   // collections will be optimized for fast writes
   // snapshoting will enable the analyzer to capture the raw data and run models against it
   var state: CompressedState = CompressedState.empty
 
   override def getState: SparklintStateLike = state
 
-  override def unEvent(event: SparkListenerEvent): Unit = synchronized {
-    event match {
-      case event: SparkListenerApplicationStart  => unAddApp(event)
-      case event: SparkListenerExecutorAdded     => unAddExecutor(event)
-      case event: SparkListenerExecutorRemoved   => unRemoveExecutor(event)
-      case event: SparkListenerBlockManagerAdded => unAddBlockManager(event)
-      case event: SparkListenerJobStart          => unJobStart(event)
-      case event: SparkListenerStageSubmitted    => unStageSubmitted(event)
-      case event: SparkListenerTaskStart         => unTaskStart(event)
-      case event: SparkListenerTaskEnd           => unTaskEnd(event)
-      case event: SparkListenerStageCompleted    => unStageCompleted(event)
-      case event: SparkListenerJobEnd            => unJobEnd(event)
-      case event: SparkListenerUnpersistRDD      => unUnpersistRDD(event)
-      case event: SparkListenerApplicationEnd    => unEndApp(event)
-      case _                                     =>
-    }
-  }
-
-  override def onEvent(listenerEvent: SparkListenerEvent): Unit = synchronized {
-    listenerEvent match {
-      case event: SparkListenerApplicationStart  => addApp(event)
-      case event: SparkListenerExecutorAdded     => addExecutor(event)
-      case event: SparkListenerExecutorRemoved   => removeExecutor(event)
-      case event: SparkListenerBlockManagerAdded => addBlockManager(event)
-      case event: SparkListenerJobStart          => jobStart(event)
-      case event: SparkListenerStageSubmitted    => stageSubmitted(event)
-      case event: SparkListenerTaskStart         => taskStart(event)
-      case event: SparkListenerTaskEnd           => taskEnd(event)
-      case event: SparkListenerStageCompleted    => stageCompleted(event)
-      case event: SparkListenerJobEnd            => jobEnd(event)
-      case event: SparkListenerUnpersistRDD      => unpersistRDD(event)
-      case event: SparkListenerApplicationEnd    => endApp(event)
-      case _                                     =>
-    }
-  }
-
-  private def addApp(event: SparkListenerApplicationStart): Unit = {
+  override def addApp(event: SparkListenerApplicationStart): Unit = {
     state = state.copy(
       //appStart = Some(event),
       lastUpdatedAt = event.time
     )
   }
 
-  private def unAddApp(event: SparkListenerApplicationStart): Unit = {
+  override def unAddApp(event: SparkListenerApplicationStart): Unit = {
     state = state.copy(
       //appStart = None,
       lastUpdatedAt = event.time
     )
   }
 
-  private def addExecutor(event: SparkListenerExecutorAdded): Unit = {
+  override def addExecutor(event: SparkListenerExecutorAdded): Unit = {
     val executorId = event.executorId
     state = state.copy(
       executorInfo = state.executorInfo + (executorId -> SparklintExecutorInfo(event.executorInfo.totalCores, event.time, None)),
       lastUpdatedAt = event.time)
   }
 
-  private def unAddExecutor(event: SparkListenerExecutorAdded): Unit = {
+  override def unAddExecutor(event: SparkListenerExecutorAdded): Unit = {
     val executorId = event.executorId
     state = state.copy(
       executorInfo = state.executorInfo - executorId,
       lastUpdatedAt = event.time)
   }
 
-  private def removeExecutor(event: SparkListenerExecutorRemoved): Unit = {
+  override def removeExecutor(event: SparkListenerExecutorRemoved): Unit = {
     val executorId = event.executorId
     state = state.copy(
       executorInfo = state.executorInfo + (executorId -> state.executorInfo(executorId).copy(endTime = Some(event.time))),
       lastUpdatedAt = event.time)
   }
 
-  private def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {
+  override def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {
     val executorId = event.executorId
     state = state.copy(
       executorInfo = state.executorInfo + (executorId -> state.executorInfo(executorId).copy(endTime = None)),
       lastUpdatedAt = event.time)
   }
 
-  private def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+  override def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
 
-  private def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+  override def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
 
-  private def jobStart(event: SparkListenerJobStart): Unit = {}
+  override def jobStart(event: SparkListenerJobStart): Unit = {}
 
-  private def unJobStart(event: SparkListenerJobStart): Unit = {}
+  override def unJobStart(event: SparkListenerJobStart): Unit = {}
 
-  private def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {
+  override def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {
     val stageId = event.stageInfo.stageId
     val stageIdentifier = StageIdentifier.fromStageInfo(event.stageInfo, event.properties)
     state = state.copy(
@@ -123,18 +86,18 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
       lastUpdatedAt = event.stageInfo.submissionTime.getOrElse(state.lastUpdatedAt))
   }
 
-  private def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {
+  override def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {
     val stageId = event.stageInfo.stageId
     state = state.copy(
       stageIdLookup = state.stageIdLookup - stageId,
       lastUpdatedAt = event.stageInfo.submissionTime.getOrElse(state.lastUpdatedAt))
   }
 
-  private def stageCompleted(event: SparkListenerStageCompleted): Unit = {}
+  override def stageCompleted(event: SparkListenerStageCompleted): Unit = {}
 
-  private def unStageCompleted(event: SparkListenerStageCompleted): Unit = {}
+  override def unStageCompleted(event: SparkListenerStageCompleted): Unit = {}
 
-  private def taskStart(event: SparkListenerTaskStart): Unit = {
+  override def taskStart(event: SparkListenerTaskStart): Unit = {
     val startTime = event.taskInfo.launchTime
     if (state.firstTaskAt.isEmpty) {
       state = state.copy(
@@ -150,7 +113,7 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
     }
   }
 
-  private def unTaskStart(event: SparkListenerTaskStart): Unit = {
+  override def unTaskStart(event: SparkListenerTaskStart): Unit = {
     val startTime = event.taskInfo.launchTime
     if (state.firstTaskAt.get == startTime) {
       state = state.copy(
@@ -166,7 +129,7 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
     }
   }
 
-  private def taskEnd(event: SparkListenerTaskEnd): Unit = {
+  override def taskEnd(event: SparkListenerTaskEnd): Unit = {
     val stageId = state.stageIdLookup(event.stageId)
     val locality = event.taskInfo.taskLocality
     state = state.copy(
@@ -182,7 +145,7 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
       lastUpdatedAt = event.taskInfo.finishTime)
   }
 
-  private def unTaskEnd(event: SparkListenerTaskEnd): Unit = {
+  override def unTaskEnd(event: SparkListenerTaskEnd): Unit = {
     val locality = event.taskInfo.taskLocality
     state = state.copy(
       coreUsage = state.coreUsage + (locality -> state.coreUsage(locality).removeUsage(
@@ -193,15 +156,15 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
       lastUpdatedAt = event.taskInfo.finishTime)
   }
 
-  private def jobEnd(event: SparkListenerJobEnd): Unit = {}
+  override def jobEnd(event: SparkListenerJobEnd): Unit = {}
 
-  private def unJobEnd(event: SparkListenerJobEnd): Unit = {}
+  override def unJobEnd(event: SparkListenerJobEnd): Unit = {}
 
-  private def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+  override def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
 
-  private def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+  override def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
 
-  private def endApp(event: SparkListenerApplicationEnd): Unit = {
+  override def endApp(event: SparkListenerApplicationEnd): Unit = {
     state = state.copy(
       executorInfo = state.executorInfo.map(pair => {
         val executorInfo = if (pair._2.endTime.isEmpty) pair._2.copy(endTime = Some(event.time)) else pair._2
@@ -211,7 +174,7 @@ class CompressedEventState(metricsBuckets: Int = 1000) extends EventStateLike {
       lastUpdatedAt = event.time)
   }
 
-  private def unEndApp(event: SparkListenerApplicationEnd): Unit = {
+  override def unEndApp(event: SparkListenerApplicationEnd): Unit = {
     state = state.copy(
       executorInfo = state.executorInfo.map(pair => {
         val executorInfo = if (pair._2.endTime.exists(_ == event.time)) pair._2.copy(endTime = None) else pair._2

--- a/src/main/scala/com/groupon/sparklint/events/EventReceiverLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventReceiverLike.scala
@@ -1,0 +1,178 @@
+/*
+ Copyright 2016 Groupon, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package com.groupon.sparklint.events
+
+import org.apache.spark.scheduler._
+
+/**
+  * The EventReceiverLike interface provides base event routing and handling for all the event recievers
+  * that are injected into an EventSource.
+  *
+  * All base methods are no-ops, implementers can chose to implement only those they need, and compose freely
+  * from other traits.  Note, teh onPreprocEvent, onOnEvent and onUnEvent handlers are called for each inbound
+  * preproc, on and un event before routing to the typed event handler for each, resulting in at least two
+  * handler calls for each event type.
+  *
+  * @author swhitear 
+  * @since 11/15/16.
+  */
+trait EventReceiverLike {
+
+  // Always called event handlers of prepreoc, on and un
+
+  def onPreprocEvent(event: SparkListenerEvent): Unit = {}
+
+  def onOnEvent(event: SparkListenerEvent): Unit = {}
+
+  def onUnEvent(event: SparkListenerEvent): Unit = {}
+
+
+  // Preprocessing base no-ops
+
+  def preprocAddApp(event: SparkListenerApplicationStart): Unit = {}
+
+  def preprocAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
+
+  def preprocRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+
+  def preprocAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+
+  def preprocJobStart(event: SparkListenerJobStart): Unit = {}
+
+  def preprocStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+
+  def preprocTaskStart(event: SparkListenerTaskStart): Unit = {}
+
+  def preprocTaskEnd(event: SparkListenerTaskEnd): Unit = {}
+
+  def preprocStageCompleted(event: SparkListenerStageCompleted): Unit = {}
+
+  def preprocJobEnd(event: SparkListenerJobEnd): Unit = {}
+
+  def preprocUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+
+  def preprocEndApp(event: SparkListenerApplicationEnd): Unit = {}
+
+
+  // On events base no-ops
+
+  def addApp(event: SparkListenerApplicationStart): Unit = {}
+
+  def addExecutor(event: SparkListenerExecutorAdded): Unit = {}
+
+  def removeExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+
+  def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+
+  def jobStart(event: SparkListenerJobStart): Unit = {}
+
+  def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+
+  def taskStart(event: SparkListenerTaskStart): Unit = {}
+
+  def taskEnd(event: SparkListenerTaskEnd): Unit = {}
+
+  def stageCompleted(event: SparkListenerStageCompleted): Unit = {}
+
+  def jobEnd(event: SparkListenerJobEnd): Unit = {}
+
+  def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+
+  def endApp(event: SparkListenerApplicationEnd): Unit = {}
+
+
+  // Un event base no-ops
+
+  def unAddApp(event: SparkListenerApplicationStart): Unit = {}
+
+  def unAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
+
+  def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+
+  def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+
+  def unJobStart(event: SparkListenerJobStart): Unit = {}
+
+  def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+
+  def unTaskStart(event: SparkListenerTaskStart): Unit = {}
+
+  def unTaskEnd(event: SparkListenerTaskEnd): Unit = {}
+
+  def unStageCompleted(event: SparkListenerStageCompleted): Unit = {}
+
+  def unJobEnd(event: SparkListenerJobEnd): Unit = {}
+
+  def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+
+  def unEndApp(event: SparkListenerApplicationEnd): Unit = {}
+
+  // Main event routers
+
+  final def preprocess(event: SparkListenerEvent): Unit = synchronized {
+    onPreprocEvent(event)
+    event match {
+      case event: SparkListenerApplicationStart  => preprocAddApp(event)
+      case event: SparkListenerExecutorAdded     => preprocAddExecutor(event)
+      case event: SparkListenerExecutorRemoved   => preprocRemoveExecutor(event)
+      case event: SparkListenerBlockManagerAdded => preprocAddBlockManager(event)
+      case event: SparkListenerJobStart          => preprocJobStart(event)
+      case event: SparkListenerStageSubmitted    => preprocStageSubmitted(event)
+      case event: SparkListenerTaskStart         => preprocTaskStart(event)
+      case event: SparkListenerTaskEnd           => preprocTaskEnd(event)
+      case event: SparkListenerStageCompleted    => preprocStageCompleted(event)
+      case event: SparkListenerJobEnd            => preprocJobEnd(event)
+      case event: SparkListenerUnpersistRDD      => preprocUnpersistRDD(event)
+      case event: SparkListenerApplicationEnd    => preprocEndApp(event)
+      case _                                     =>
+    }
+  }
+
+ final def onEvent(event: SparkListenerEvent): Unit = synchronized {
+   onOnEvent(event)
+   event match {
+      case event: SparkListenerApplicationStart  => addApp(event)
+      case event: SparkListenerExecutorAdded     => addExecutor(event)
+      case event: SparkListenerExecutorRemoved   => removeExecutor(event)
+      case event: SparkListenerBlockManagerAdded => addBlockManager(event)
+      case event: SparkListenerJobStart          => jobStart(event)
+      case event: SparkListenerStageSubmitted    => stageSubmitted(event)
+      case event: SparkListenerTaskStart         => taskStart(event)
+      case event: SparkListenerTaskEnd           => taskEnd(event)
+      case event: SparkListenerStageCompleted    => stageCompleted(event)
+      case event: SparkListenerJobEnd            => jobEnd(event)
+      case event: SparkListenerUnpersistRDD      => unpersistRDD(event)
+      case event: SparkListenerApplicationEnd    => endApp(event)
+      case _                                     =>
+    }
+  }
+
+  final def unEvent(event: SparkListenerEvent): Unit = synchronized {
+    onUnEvent(event)
+    event match {
+      case event: SparkListenerApplicationStart  => unAddApp(event)
+      case event: SparkListenerExecutorAdded     => unAddExecutor(event)
+      case event: SparkListenerExecutorRemoved   => unRemoveExecutor(event)
+      case event: SparkListenerBlockManagerAdded => unAddBlockManager(event)
+      case event: SparkListenerJobStart          => unJobStart(event)
+      case event: SparkListenerStageSubmitted    => unStageSubmitted(event)
+      case event: SparkListenerTaskStart         => unTaskStart(event)
+      case event: SparkListenerTaskEnd           => unTaskEnd(event)
+      case event: SparkListenerStageCompleted    => unStageCompleted(event)
+      case event: SparkListenerJobEnd            => unJobEnd(event)
+      case event: SparkListenerUnpersistRDD      => unUnpersistRDD(event)
+      case event: SparkListenerApplicationEnd    => unEndApp(event)
+      case _                                     =>
+    }
+  }
+}

--- a/src/main/scala/com/groupon/sparklint/events/EventReceiverLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventReceiverLike.scala
@@ -15,11 +15,11 @@ package com.groupon.sparklint.events
 import org.apache.spark.scheduler._
 
 /**
-  * The EventReceiverLike interface provides base event routing and handling for all the event recievers
+  * The EventReceiverLike interface provides base event routing and handling for all the event receivers
   * that are injected into an EventSource.
   *
   * All base methods are no-ops, implementers can chose to implement only those they need, and compose freely
-  * from other traits.  Note, teh onPreprocEvent, onOnEvent and onUnEvent handlers are called for each inbound
+  * from other traits.  Note, the onPreprocEvent, onOnEvent and onUnEvent handlers are called for each inbound
   * preproc, on and un event before routing to the typed event handler for each, resulting in at least two
   * handler calls for each event type.
   *
@@ -30,96 +30,96 @@ trait EventReceiverLike {
 
   // Always called event handlers of prepreoc, on and un
 
-  def onPreprocEvent(event: SparkListenerEvent): Unit = {}
+  protected def onPreprocEvent(event: SparkListenerEvent): Unit = {}
 
-  def onOnEvent(event: SparkListenerEvent): Unit = {}
+  protected def onOnEvent(event: SparkListenerEvent): Unit = {}
 
-  def onUnEvent(event: SparkListenerEvent): Unit = {}
+  protected def onUnEvent(event: SparkListenerEvent): Unit = {}
 
 
   // Preprocessing base no-ops
 
-  def preprocAddApp(event: SparkListenerApplicationStart): Unit = {}
+  protected def preprocAddApp(event: SparkListenerApplicationStart): Unit = {}
 
-  def preprocAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
+  protected def preprocAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
 
-  def preprocRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+  protected def preprocRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
 
-  def preprocAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+  protected def preprocAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
 
-  def preprocJobStart(event: SparkListenerJobStart): Unit = {}
+  protected def preprocJobStart(event: SparkListenerJobStart): Unit = {}
 
-  def preprocStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+  protected def preprocStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
 
-  def preprocTaskStart(event: SparkListenerTaskStart): Unit = {}
+  protected def preprocTaskStart(event: SparkListenerTaskStart): Unit = {}
 
-  def preprocTaskEnd(event: SparkListenerTaskEnd): Unit = {}
+  protected def preprocTaskEnd(event: SparkListenerTaskEnd): Unit = {}
 
-  def preprocStageCompleted(event: SparkListenerStageCompleted): Unit = {}
+  protected def preprocStageCompleted(event: SparkListenerStageCompleted): Unit = {}
 
-  def preprocJobEnd(event: SparkListenerJobEnd): Unit = {}
+  protected def preprocJobEnd(event: SparkListenerJobEnd): Unit = {}
 
-  def preprocUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+  protected def preprocUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
 
-  def preprocEndApp(event: SparkListenerApplicationEnd): Unit = {}
+  protected def preprocEndApp(event: SparkListenerApplicationEnd): Unit = {}
 
 
   // On events base no-ops
 
-  def addApp(event: SparkListenerApplicationStart): Unit = {}
+  protected def addApp(event: SparkListenerApplicationStart): Unit = {}
 
-  def addExecutor(event: SparkListenerExecutorAdded): Unit = {}
+  protected def addExecutor(event: SparkListenerExecutorAdded): Unit = {}
 
-  def removeExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+  protected def removeExecutor(event: SparkListenerExecutorRemoved): Unit = {}
 
-  def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+  protected def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
 
-  def jobStart(event: SparkListenerJobStart): Unit = {}
+  protected def jobStart(event: SparkListenerJobStart): Unit = {}
 
-  def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+  protected def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
 
-  def taskStart(event: SparkListenerTaskStart): Unit = {}
+  protected def taskStart(event: SparkListenerTaskStart): Unit = {}
 
-  def taskEnd(event: SparkListenerTaskEnd): Unit = {}
+  protected def taskEnd(event: SparkListenerTaskEnd): Unit = {}
 
-  def stageCompleted(event: SparkListenerStageCompleted): Unit = {}
+  protected def stageCompleted(event: SparkListenerStageCompleted): Unit = {}
 
-  def jobEnd(event: SparkListenerJobEnd): Unit = {}
+  protected def jobEnd(event: SparkListenerJobEnd): Unit = {}
 
-  def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+  protected def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
 
-  def endApp(event: SparkListenerApplicationEnd): Unit = {}
+  protected def endApp(event: SparkListenerApplicationEnd): Unit = {}
 
 
   // Un event base no-ops
 
-  def unAddApp(event: SparkListenerApplicationStart): Unit = {}
+  protected def unAddApp(event: SparkListenerApplicationStart): Unit = {}
 
-  def unAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
+  protected def unAddExecutor(event: SparkListenerExecutorAdded): Unit = {}
 
-  def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
+  protected def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = {}
 
-  def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
+  protected def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = {}
 
-  def unJobStart(event: SparkListenerJobStart): Unit = {}
+  protected def unJobStart(event: SparkListenerJobStart): Unit = {}
 
-  def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
+  protected def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {}
 
-  def unTaskStart(event: SparkListenerTaskStart): Unit = {}
+  protected def unTaskStart(event: SparkListenerTaskStart): Unit = {}
 
-  def unTaskEnd(event: SparkListenerTaskEnd): Unit = {}
+  protected def unTaskEnd(event: SparkListenerTaskEnd): Unit = {}
 
-  def unStageCompleted(event: SparkListenerStageCompleted): Unit = {}
+  protected def unStageCompleted(event: SparkListenerStageCompleted): Unit = {}
 
-  def unJobEnd(event: SparkListenerJobEnd): Unit = {}
+  protected def unJobEnd(event: SparkListenerJobEnd): Unit = {}
 
-  def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
+  protected def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = {}
 
-  def unEndApp(event: SparkListenerApplicationEnd): Unit = {}
+  protected def unEndApp(event: SparkListenerApplicationEnd): Unit = {}
 
   // Main event routers
 
-  final def preprocess(event: SparkListenerEvent): Unit = synchronized {
+  def preprocess(event: SparkListenerEvent): Unit = synchronized {
     onPreprocEvent(event)
     event match {
       case event: SparkListenerApplicationStart  => preprocAddApp(event)
@@ -138,7 +138,7 @@ trait EventReceiverLike {
     }
   }
 
- final def onEvent(event: SparkListenerEvent): Unit = synchronized {
+  def onEvent(event: SparkListenerEvent): Unit = synchronized {
    onOnEvent(event)
    event match {
       case event: SparkListenerApplicationStart  => addApp(event)
@@ -157,7 +157,7 @@ trait EventReceiverLike {
     }
   }
 
-  final def unEvent(event: SparkListenerEvent): Unit = synchronized {
+  def unEvent(event: SparkListenerEvent): Unit = synchronized {
     onUnEvent(event)
     event match {
       case event: SparkListenerApplicationStart  => unAddApp(event)

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceBase.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceBase.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable.HashMap
   * @author swhitear 
   * @since 9/29/16.
   */
-abstract class EventSourceBase() extends EventSourceLike {
+trait EventSourceBase extends EventSourceLike {
 
   type EnvironmentData = Map[String, Seq[(String, String)]]
 

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceBase.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceBase.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable.HashMap
   * @author swhitear 
   * @since 9/29/16.
   */
-abstract class EventSourceBase(eventState: EventStateLike) extends EventSourceLike {
+abstract class EventSourceBase() extends EventSourceLike {
 
   type EnvironmentData = Map[String, Seq[(String, String)]]
 

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceFactory.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceFactory.scala
@@ -1,0 +1,19 @@
+package com.groupon.sparklint.events
+
+/**
+  * A simple trait to wrap a factory for constructing various combinations of EventSourceLike and their receivers.
+  *
+  * @author swhitear 
+  * @since 11/18/16.
+  */
+trait EventSourceFactory[CtorT] {
+
+  /**
+    * Build a combination of EventSourceLike, EventStateLike and EventProgressLike objects.
+    *
+    * @param ctorVal the generic .ctor param for the concrete instance to construct the EventSourceDetail from.
+    * @return the EventSourceDetail instance.
+    */
+  def buildEventSourceDetail(ctorVal: CtorT): Option[EventSourceDetail]
+
+}

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceLike.scala
@@ -13,7 +13,6 @@
 package com.groupon.sparklint.events
 
 import com.groupon.sparklint.common.Utils
-import com.groupon.sparklint.data.SparklintStateLike
 
 /**
   * The EventSourceLike provides a set of Spark events from a specific source.
@@ -44,10 +43,6 @@ trait EventSourceLike {
   def startTime: Long
 
   def endTime: Long
-
-  def progress: EventSourceProgress
-
-  def state: SparklintStateLike
 
   def fullName: String
 

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
@@ -45,11 +45,13 @@ class EventSourceManager(initialSources: EventSourceDetail*) extends EventSource
   @throws[NoSuchElementException]
   override def getScrollingSource(appId: String): FreeScrollEventSource = {
     eventSourcesByAppId.get(appId) match {
-      case Some(eventSource: FreeScrollEventSource) => eventSource
-      case Some(_)                                  => throw new IllegalArgumentException(s"$appId cannot free scroll")
-      case None                                     => throw new NoSuchElementException(s"Missing appId $appId")
+      case Some(EventSourceDetail(eventSource: FreeScrollEventSource, p: EventSourceProgressLike, s: EventStateLike))
+                   => eventSource
+      case Some(_) => throw new IllegalArgumentException(s"$appId cannot free scroll")
+      case None    => throw new NoSuchElementException(s"Missing appId $appId")
     }
   }
 
-  @throws[NoSuchElementException]
-  override def getSourceDetail(appId: String): EventSourceDetail = eventSourcesByAppId(appId)}
+    @throws[NoSuchElementException]
+    override def getSourceDetail(appId: String): EventSourceDetail = eventSourcesByAppId(appId)
+  }

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
@@ -21,26 +21,26 @@ import scala.collection.mutable
   * @author swhitear 
   * @since 8/18/16.
   */
-class EventSourceManager(initialSources: EventSourceLike*) extends EventSourceManagerLike {
+class EventSourceManager(initialSources: EventSourceDetail*) extends EventSourceManagerLike {
 
   // this sync'ed LinkedHashMap is necessary because we want to ensure ordering of items in the manager, not the UI.
   // insertion order works well enough here, we have no need for any other guarantees from the data structure.
-  private val eventSourcesByAppId = new mutable.LinkedHashMap[String, EventSourceLike]()
-                                        with mutable.SynchronizedMap[String, EventSourceLike]
-  initialSources.foreach(es => eventSourcesByAppId += (es.appId -> es))
+  private val eventSourcesByAppId = new mutable.LinkedHashMap[String, EventSourceDetail]()
+                                        with mutable.SynchronizedMap[String, EventSourceDetail]
+  initialSources.foreach(es => eventSourcesByAppId += (es.source.appId -> es))
 
-  override def addEventSource(eventSource: EventSourceLike): Unit = {
-    eventSourcesByAppId.put(eventSource.appId, eventSource)
+  override def addEventSource(eventDetail: EventSourceDetail): Unit = {
+    eventSourcesByAppId.put(eventDetail.source.appId, eventDetail)
   }
 
   override def sourceCount: Int = eventSourcesByAppId.size
 
-  override def eventSources: Iterable[EventSourceLike] = eventSourcesByAppId.values
+  override def eventSource: Iterable[EventSourceDetail] = eventSourcesByAppId.values
 
   override def containsAppId(appId: String): Boolean = eventSourcesByAppId.contains(appId)
 
   @throws[NoSuchElementException]
-  override def getSource(appId: String): EventSourceLike = eventSourcesByAppId(appId)
+  override def getSource(appId: String): EventSourceLike = eventSourcesByAppId(appId).source
 
   @throws[NoSuchElementException]
   override def getScrollingSource(appId: String): FreeScrollEventSource = {
@@ -50,4 +50,6 @@ class EventSourceManager(initialSources: EventSourceLike*) extends EventSourceMa
       case None                                     => throw new NoSuchElementException(s"Missing appId $appId")
     }
   }
-}
+
+  @throws[NoSuchElementException]
+  override def getSourceDetail(appId: String): EventSourceDetail = eventSourcesByAppId(appId)}

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceManager.scala
@@ -35,23 +35,23 @@ class EventSourceManager(initialSources: EventSourceDetail*) extends EventSource
 
   override def sourceCount: Int = eventSourcesByAppId.size
 
-  override def eventSource: Iterable[EventSourceDetail] = eventSourcesByAppId.values
+  override def eventSources: Iterable[EventSourceDetail] = eventSourcesByAppId.values
 
   override def containsAppId(appId: String): Boolean = eventSourcesByAppId.contains(appId)
 
   @throws[NoSuchElementException]
-  override def getSource(appId: String): EventSourceLike = eventSourcesByAppId(appId).source
+  override def getSource(appId: String): EventSourceDetail = eventSourcesByAppId(appId)
 
   @throws[NoSuchElementException]
   override def getScrollingSource(appId: String): FreeScrollEventSource = {
     eventSourcesByAppId.get(appId) match {
-      case Some(EventSourceDetail(eventSource: FreeScrollEventSource, p: EventSourceProgressLike, s: EventStateLike))
-                   => eventSource
-      case Some(_) => throw new IllegalArgumentException(s"$appId cannot free scroll")
-      case None    => throw new NoSuchElementException(s"Missing appId $appId")
+      case Some(EventSourceDetail(source: FreeScrollEventSource, s: Any, p: Any)) => source
+      case Some(_)                                                                => scrollFail(appId)
+      case None                                                                   => idFail(appId)
     }
   }
 
-    @throws[NoSuchElementException]
-    override def getSourceDetail(appId: String): EventSourceDetail = eventSourcesByAppId(appId)
-  }
+  private def scrollFail(appId: String) = throw new IllegalArgumentException(s"$appId cannot free scroll")
+
+  private def idFail(appId: String) = throw new NoSuchElementException(s"Missing appId $appId")
+}

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceManagerLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceManagerLike.scala
@@ -26,7 +26,7 @@ trait EventSourceManagerLike {
     *
     * @param eventSource the EventSourceLike extending implementation to add.
     */
-  def addEventSource(eventSource: EventSourceLike): Unit
+  def addEventSource(eventSource: EventSourceDetail): Unit
 
   /**
     * The number of sources currently in the manager.
@@ -36,11 +36,11 @@ trait EventSourceManagerLike {
   def sourceCount: Int
 
   /**
-    * An Iterable of EventSourceLike instances returned in their insertion order.
+    * An Iterable of SourceDetail instances returned in their EventSourceLike insertion order that the .
     *
     * @return
     */
-  def eventSources: Iterable[EventSourceLike]
+  def eventSource: Iterable[EventSourceDetail]
 
   /** True if the current set of managed EventSourceLike instances contains the specified appId.
     *
@@ -62,4 +62,9 @@ trait EventSourceManagerLike {
   @throws[NoSuchElementException]
   def getScrollingSource(appId: String): FreeScrollEventSource
 
+  @throws[NoSuchElementException]
+  def getSourceDetail(appId: String): EventSourceDetail
+
 }
+
+case class EventSourceDetail(source: EventSourceLike, progress: EventSourceProgressLike, state: EventStateLike)

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceManagerLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceManagerLike.scala
@@ -12,6 +12,12 @@
 */
 package com.groupon.sparklint.events
 
+import java.io.File
+
+import com.groupon.sparklint.SparklintServer._
+
+import scala.util.{Failure, Success, Try}
+
 /**
   * Implementations of this trait are capable of managing the list of event sources for a specific configuration of
   * Sparklint.
@@ -22,9 +28,9 @@ package com.groupon.sparklint.events
 trait EventSourceManagerLike {
 
   /**
-    * Adds an EventSourceLike instance to the manager.
+    * Adds an EventSourceDetail instance to the manager.
     *
-    * @param eventSource the EventSourceLike extending implementation to add.
+    * @param eventSource the EventSourceDetail instance to add.
     */
   def addEventSource(eventSource: EventSourceDetail): Unit
 
@@ -36,11 +42,11 @@ trait EventSourceManagerLike {
   def sourceCount: Int
 
   /**
-    * An Iterable of SourceDetail instances returned in their EventSourceLike insertion order that the .
+    * An Iterable of EventSourceDetail instances returned in their insertion order.
     *
     * @return
     */
-  def eventSource: Iterable[EventSourceDetail]
+  def eventSources: Iterable[EventSourceDetail]
 
   /** True if the current set of managed EventSourceLike instances contains the specified appId.
     *
@@ -57,14 +63,16 @@ trait EventSourceManagerLike {
     * @return The specified EventSourceLike instance.
     */
   @throws[NoSuchElementException]
-  def getSource(appId: String): EventSourceLike
+  def getSource(appId: String): EventSourceDetail
 
   @throws[NoSuchElementException]
   def getScrollingSource(appId: String): FreeScrollEventSource
 
-  @throws[NoSuchElementException]
-  def getSourceDetail(appId: String): EventSourceDetail
-
 }
 
-case class EventSourceDetail(source: EventSourceLike, progress: EventSourceProgressLike, state: EventStateLike)
+case class EventSourceDetail(source: EventSourceLike, state: EventStateLike, progress: EventSourceProgressLike) {
+  def forwardIfPossible() = source match {
+    case scrollable: FreeScrollEventSource => scrollable.toEnd()
+    case _ =>
+  }
+}

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceProgress.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceProgress.scala
@@ -25,10 +25,10 @@ import scala.collection.mutable
   * @since 9/12/16.
   */
 @throws[IllegalArgumentException]
-case class EventSourceProgress(eventProgress: EventProgressLike = EventProgress.empty(),
-                               taskProgress: EventProgressLike = EventProgress.empty(),
-                               stageProgress: EventProgressLike = EventProgress.empty(),
-                               jobProgress: EventProgressLike = EventProgress.empty())
+class EventSourceProgress(val eventProgress: EventProgressLike = EventProgress.empty(),
+                          val taskProgress: EventProgressLike = EventProgress.empty(),
+                          val stageProgress: EventProgressLike = EventProgress.empty(),
+                          val  jobProgress: EventProgressLike = EventProgress.empty())
   extends EventSourceProgressLike with EventReceiverLike {
 
   require(eventProgress != null)
@@ -106,7 +106,6 @@ case class EventSourceProgress(eventProgress: EventProgressLike = EventProgress.
 
   override def jobStart(event: SparkListenerJobStart): Unit = {
     jobProgress.started += 1
-    val name = jobNameFromInfo(event)
     jobProgress.active = jobProgress.active + jobNameFromInfo(event)
   }
 
@@ -150,7 +149,7 @@ trait EventSourceProgressLike {
   val jobProgress  : EventProgressLike
 }
 
-case class EventProgress(var count: Int, var started: Int, var complete: Int, var active: Set[String])
+class EventProgress(var count: Int, var started: Int, var complete: Int, var active: Set[String])
   extends EventProgressLike {
   require(count >= 0)
   require(started >= 0 && started <= count)
@@ -167,8 +166,8 @@ case class EventProgress(var count: Int, var started: Int, var complete: Int, va
   private def activeString = if (active.isEmpty) "" else s" (${active.mkString(", ")})"
 }
 
-case object EventProgress {
-  def empty(): EventProgress = EventProgress(0, 0, 0, Set.empty)
+object EventProgress {
+  def empty(): EventProgress = new EventProgress(0, 0, 0, Set.empty)
 }
 
 trait EventProgressLike {

--- a/src/main/scala/com/groupon/sparklint/events/EventSourceProgress.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventSourceProgress.scala
@@ -12,28 +12,182 @@
 */
 package com.groupon.sparklint.events
 
+import com.groupon.sparklint.common.Utils
+import org.apache.spark.scheduler._
+
+import scala.collection.mutable
+
 /**
-  * A simple case class that provides information about the pointer progress of a specific EventSourceLike
-  * implementation.
+  * A case class that provides various information about the pointer progress of a specific EventSource through
+  * the event receiver interface.
   *
   * @author swhitear 
   * @since 9/12/16.
   */
 @throws[IllegalArgumentException]
-case class EventSourceProgress(count: Int, index: Int) {
+case class EventSourceProgress(eventProgress: EventProgressLike = EventProgress.empty(),
+                               taskProgress: EventProgressLike = EventProgress.empty(),
+                               stageProgress: EventProgressLike = EventProgress.empty(),
+                               jobProgress: EventProgressLike = EventProgress.empty())
+  extends EventSourceProgressLike with EventReceiverLike {
+
+  require(eventProgress != null)
+  require(taskProgress != null)
+  require(stageProgress != null)
+  require(jobProgress != null)
+
+  private val jobTracker = mutable.Map.empty[Int, String]
+
+  override def onPreprocEvent(event: SparkListenerEvent): Unit = {
+    eventProgress.count += 1
+  }
+
+  override def preprocTaskEnd(event: SparkListenerTaskEnd): Unit = {
+    taskProgress.count += 1
+  }
+
+  override def preprocStageCompleted(event: SparkListenerStageCompleted): Unit = {
+    stageProgress.count += 1
+  }
+
+  override def preprocJobEnd(event: SparkListenerJobEnd): Unit = {
+    jobProgress.count += 1
+  }
+
+  override def onOnEvent(event: SparkListenerEvent): Unit = {
+    eventProgress.started += 1
+    eventProgress.complete += 1
+  }
+
+  override def onUnEvent(event: SparkListenerEvent): Unit = {
+    eventProgress.started -= 1
+    eventProgress.complete -= 1
+  }
+
+  override def taskStart(event: SparkListenerTaskStart): Unit = {
+    taskProgress.started += 1
+    taskProgress.active = taskProgress.active + taskNameFromInfo(event.taskInfo)
+  }
+
+  override def taskEnd(event: SparkListenerTaskEnd): Unit = {
+    taskProgress.complete += 1
+    taskProgress.active = taskProgress.active - taskNameFromInfo(event.taskInfo)
+  }
+
+  override def unTaskStart(event: SparkListenerTaskStart): Unit = {
+    taskProgress.started -= 1
+    taskProgress.active = taskProgress.active - taskNameFromInfo(event.taskInfo)
+  }
+
+  override def unTaskEnd(event: SparkListenerTaskEnd): Unit = {
+    taskProgress.complete -= 1
+    taskProgress.active = taskProgress.active + taskNameFromInfo(event.taskInfo)
+  }
+
+  override def stageSubmitted(event: SparkListenerStageSubmitted): Unit = {
+    stageProgress.started += 1
+    stageProgress.active = stageProgress.active + event.stageInfo.name
+  }
+
+  override def stageCompleted(event: SparkListenerStageCompleted): Unit = {
+    stageProgress.complete += 1
+    stageProgress.active = stageProgress.active - event.stageInfo.name
+  }
+
+  override def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = {
+    stageProgress.started -= 1
+    stageProgress.active = stageProgress.active - event.stageInfo.name
+  }
+
+  override def unStageCompleted(event: SparkListenerStageCompleted): Unit = {
+    stageProgress.complete -= 1
+    stageProgress.active = taskProgress.active + event.stageInfo.name
+  }
+
+  override def jobStart(event: SparkListenerJobStart): Unit = {
+    jobProgress.started += 1
+    val name = jobNameFromInfo(event)
+    jobProgress.active = jobProgress.active + jobNameFromInfo(event)
+  }
+
+  override def jobEnd(event: SparkListenerJobEnd): Unit = {
+    jobProgress.complete += 1
+    jobProgress.active = jobProgress.active - jobNameFromId(event.jobId)
+  }
+
+  override def unJobStart(event: SparkListenerJobStart): Unit = {
+    jobProgress.started -= 1
+    jobProgress.active = jobProgress.active - jobNameFromInfo(event)
+  }
+
+  override def unJobEnd(event: SparkListenerJobEnd): Unit = {
+    jobProgress.complete -= 1
+    jobProgress.active = jobProgress.active + jobNameFromId(event.jobId)
+  }
+
+  override def toString: String =
+    s"Event: $eventProgress, Task: $taskProgress, Stage: $stageProgress, Job: $jobProgress"
+
+  private def taskNameFromInfo(taskInf: TaskInfo) =
+    s"ID${taskInf.taskId}:${taskInf.taskLocality}:${taskInf.host}(attempt ${taskInf.attemptNumber})"
+
+  private def jobNameFromInfo(event: SparkListenerJobStart): String = {
+    val props = event.properties
+    val propertyExtract = s"${props.getProperty("spark.job.description", Utils.UNKNOWN_STRING)}"
+    val name = s"ID${event.jobId}:$propertyExtract"
+    jobTracker.getOrElseUpdate(event.jobId, name)
+  }
+
+  private def jobNameFromId(id: Int): String = {
+    jobTracker(id)
+  }
+}
+
+trait EventSourceProgressLike {
+  val eventProgress: EventProgressLike
+  val taskProgress : EventProgressLike
+  val stageProgress: EventProgressLike
+  val jobProgress  : EventProgressLike
+}
+
+case class EventProgress(var count: Int, var started: Int, var complete: Int, var active: Set[String])
+  extends EventProgressLike {
   require(count >= 0)
-  require(index >= 0)
-  require(index <= count)
+  require(started >= 0 && started <= count)
+  require(complete >= 0 && complete <= count)
+  require(complete <= started)
+  require(active != null)
 
-  private val safeCount: Double = if (count == 0) 1 else count
+  def safeCount: Double = if (count == 0) 1 else count
 
-  val hasNext = index < count
+  def percent = ((complete / safeCount) * 100).round
 
-  val hasPrevious = index > 0
+  def description = s"Completed $complete / $count ($percent%) with $inFlightCount active$activeString."
 
-  val percent = ((index / safeCount) * 100).round
+  private def activeString = if (active.isEmpty) "" else s" (${active.mkString(", ")})"
+}
 
-  val description = s"$index / $count ($percent%)"
+case object EventProgress {
+  def empty(): EventProgress = EventProgress(0, 0, 0, Set.empty)
+}
 
-  override def toString: String = s"$index of $count"
+trait EventProgressLike {
+
+  var count   : Int
+  var started : Int
+  var complete: Int
+  var active  : Set[String]
+
+  def percent: Long
+
+  def description: String
+
+  def hasNext = complete < count
+
+  def hasPrevious = complete > 0
+
+  def inFlightCount = started - complete
+
+  override def toString: String = s"$complete of $count with $inFlightCount active"
+
 }

--- a/src/main/scala/com/groupon/sparklint/events/EventStateLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventStateLike.scala
@@ -22,21 +22,7 @@ import org.apache.spark.scheduler.SparkListenerEvent
   * @author swhitear 
   * @since 9/10/16.
   */
-trait EventStateLike {
-
-  /**
-    * Modify the EventState by adding the specified message.
-    *
-    * @param event the SparkListenerEvent class to add.
-    */
-  def onEvent(event: SparkListenerEvent): Unit
-
-  /**
-    * Modify the EventState by removing the specified message.
-    *
-    * @param event the SparkListenerEvent class to add.
-    */
-  def unEvent(event: SparkListenerEvent): Unit
+trait EventStateLike extends EventReceiverLike {
 
   /**
     * The current EventState represented as a SparklintState object.
@@ -44,7 +30,5 @@ trait EventStateLike {
     * @return the SparklintState object representing current state.
     */
   def getState: SparklintStateLike
-
-
 
 }

--- a/src/main/scala/com/groupon/sparklint/events/EventStateLike.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventStateLike.scala
@@ -45,4 +45,6 @@ trait EventStateLike {
     */
   def getState: SparklintStateLike
 
+
+
 }

--- a/src/main/scala/com/groupon/sparklint/events/EventType.scala
+++ b/src/main/scala/com/groupon/sparklint/events/EventType.scala
@@ -1,0 +1,46 @@
+/*
+ Copyright 2016 Groupon, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package com.groupon.sparklint.events
+
+/**
+  * A set of case classes that represent the available EventSource types.
+  *
+  * @author swhitear 
+  * @since 11/7/16.
+  */
+abstract class EventType(description: String)
+
+object EventType {
+  val EVENTS = "Events"
+  val TASKS  = "Tasks"
+  val STAGES = "Stages"
+  val JOBS   = "Jobs"
+
+  val ALL_TYPES = Seq(EVENTS, TASKS, STAGES, JOBS)
+
+  def fromString(eventType: String): EventType = eventType match {
+    case EVENTS => Events()
+    case TASKS  => Tasks()
+    case STAGES => Stages()
+    case JOBS   => Jobs()
+  }
+}
+
+case class Events() extends EventType(EventType.EVENTS)
+
+case class Tasks() extends EventType(EventType.EVENTS)
+
+case class Stages() extends EventType(EventType.EVENTS)
+
+case class Jobs() extends EventType(EventType.EVENTS)
+

--- a/src/main/scala/com/groupon/sparklint/events/FileEventSource.scala
+++ b/src/main/scala/com/groupon/sparklint/events/FileEventSource.scala
@@ -16,7 +16,6 @@ import java.io.File
 
 import com.groupon.sparklint.SparklintServer._
 import com.groupon.sparklint.common.Logging
-import com.groupon.sparklint.data.SparklintStateLike
 import org.apache.spark.groupon.{SparkListenerLogStartShim, StringToSparkEvent}
 import org.apache.spark.scheduler.{SparkListenerEvent, SparkListenerTaskEnd, _}
 
@@ -31,49 +30,49 @@ import scala.util.{Failure, Success, Try}
   * @since 8/18/16.
   */
 @throws[IllegalArgumentException]
-case class FileEventSource(fileSource: File, eventState: EventStateLike)
-  extends EventSourceBase(eventState) with FreeScrollEventSource with Logging {
+case class FileEventSource(fileSource: File, receivers: Seq[EventReceiverLike])
+  extends EventSourceBase() with FreeScrollEventSource with Logging {
 
   // important to declare this before the buffer is filled
-  private var extractedId: Option[String] = None
+  private var extractedId = Option.empty[String]
 
-  private val buffer  = new EventBuffer(fillBuffer())
-  private val fScroll = new ScrollHandler(buffer.next, eventState.onEvent, !buffer.hasNext, progress)
-  private val bScroll = new ScrollHandler(buffer.previous, eventState.unEvent, !buffer.hasPrevious, progress)
+  private val buffer    = new EventBuffer(fillBuffer())
+  private val fwdScroll = new ScrollHandler(buffer.next, onEvent, !buffer.hasNext)
+  private val rewScroll = new ScrollHandler(buffer.previous, unEvent, !buffer.hasPrevious)
 
   override val appId: String = extractedId.getOrElse(fileSource.getName)
 
   @throws[IllegalArgumentException]
-  def forwardEvents(count: Int = 1) = fScroll.scroll(count)
+  def forwardEvents(count: Int = 1) = fwdScroll.scroll(count)
 
   @throws[IllegalArgumentException]
-  def rewindEvents(count: Int = 1) = bScroll.scroll(count)
+  def rewindEvents(count: Int = 1) = rewScroll.scroll(count)
 
   @throws[IllegalArgumentException]
-  def forwardTasks(count: Int = 1) = fScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerTaskEnd])
+  def forwardTasks(count: Int = 1) = fwdScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerTaskEnd])
 
   @throws[IllegalArgumentException]
-  def rewindTasks(count: Int = 1) = bScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerTaskStart])
+  def rewindTasks(count: Int = 1) = rewScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerTaskStart])
 
   @throws[IllegalArgumentException]
-  def forwardStages(count: Int = 1) = fScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerStageCompleted])
+  def forwardStages(count: Int = 1) = fwdScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerStageCompleted])
 
   @throws[IllegalArgumentException]
-  def rewindStages(count: Int = 1) = bScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerStageSubmitted])
+  def rewindStages(count: Int = 1) = rewScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerStageSubmitted])
 
   @throws[IllegalArgumentException]
-  def forwardJobs(count: Int = 1) = fScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerJobEnd])
+  def forwardJobs(count: Int = 1) = fwdScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerJobEnd])
 
   @throws[IllegalArgumentException]
-  def rewindJobs(count: Int = 1) = bScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerJobStart])
+  def rewindJobs(count: Int = 1) = rewScroll.scroll(count, (evt) => evt.isInstanceOf[SparkListenerJobStart])
 
-  override def toEnd(): EventSourceProgress = fScroll.scroll(Int.MaxValue)
+  override def toEnd() = fwdScroll.scroll(Int.MaxValue)
 
-  override def toStart(): EventSourceProgress = bScroll.scroll(Int.MaxValue)
+  override def toStart() = rewScroll.scroll(Int.MaxValue)
 
-  override def progress: EventSourceProgress = EventSourceProgress(buffer.eventCount, buffer.index)
+  override def hasNext: Boolean = buffer.hasNext
 
-  override def state: SparklintStateLike = eventState.getState
+  override def hasPrevious: Boolean = buffer.hasPrevious
 
   private def fillBuffer(): IndexedSeq[SparkListenerEvent] = {
     Try(Source.fromFile(fileSource)) match {
@@ -91,7 +90,7 @@ case class FileEventSource(fileSource: File, eventState: EventStateLike)
       case event: SparkListenerEnvironmentUpdate => setEnvironmentState(event)
       case event: SparkListenerApplicationStart  => setAppStartState(event)
       case event: SparkListenerApplicationEnd    => setAppEndState(event)
-      case default                               => Some(default)
+      case default                               => prepreocessEvent(default)
     }
   }
 
@@ -117,42 +116,54 @@ case class FileEventSource(fileSource: File, eventState: EventStateLike)
     appNameOpt = Some(event.appName)
     userOpt = Some(event.sparkUser)
     startTimeOpt = Some(event.time)
-    event // include the event in the buffer
+    prepreocessEvent(event)  // include the event in the buffer
   }
 
   private def setAppEndState(event: SparkListenerApplicationEnd): Option[SparkListenerEvent] = {
     endTimeOpt = Some(event.time)
-    event // include the event in the buffer
+    prepreocessEvent(event) // include the event in the buffer
   }
+
+  private def prepreocessEvent(event: SparkListenerEvent) = {
+    receivers.foreach(_.preprocess(event))
+    Some(event)
+  }
+
+  private def onEvent(event: SparkListenerEvent) = receivers.foreach(_.onEvent(event))
+
+  private def unEvent(event: SparkListenerEvent) = receivers.foreach(_.unEvent(event))
+
 }
 
 object FileEventSource {
-  def apply(fileSource: File, runImmediately: Boolean): Option[FileEventSource] = Try {
-    val eventSource = new FileEventSource(fileSource, new LosslessEventState())
-    if (runImmediately) {
-      logInfo(s"Auto playing event source ${eventSource.fullName}")
-      while (eventSource.progress.hasNext) {
-        eventSource.forwardEvents()
+  def apply(fileSource: File, runImmediately: Boolean): Option[EventSourceDetail] = {
+    val progressReceiver = EventSourceProgress()
+    val stateReceiver = new LosslessEventState()
+    Try {
+      val eventReceivers = Seq(progressReceiver, stateReceiver)
+      val eventSource = new FileEventSource(fileSource, eventReceivers)
+      if (runImmediately) {
+        logInfo(s"Auto playing event source ${eventSource.fullName}")
+        eventSource.toEnd()
       }
+      eventSource
+    } match {
+      case Success(eventSource) =>
+        logInfo(s"Successfully created file source ${fileSource.getName}")
+        Some(EventSourceDetail(eventSource, progressReceiver, stateReceiver))
+      case Failure(ex)          =>
+        logWarn(s"Failure creating file source from ${fileSource.getName}: ${ex.getMessage}")
+        None
     }
-    eventSource
-  } match {
-    case Success(eventSource) =>
-      logInfo(s"Successfully created file source ${fileSource.getName}")
-      Some(eventSource)
-    case Failure(ex)          =>
-      logWarn(s"Failure creating file source from ${fileSource.getName}: ${ex.getMessage}")
-      None
   }
 }
 
 private class ScrollHandler(movefn: () => SparkListenerEvent,
                             statefn: (SparkListenerEvent) => Unit,
-                            breaker: => Boolean,
-                            progress: => EventSourceProgress) {
+                            breaker: => Boolean) {
 
   @throws[scala.IllegalArgumentException]
-  def scroll(count: Int, decrementfn: (SparkListenerEvent) => Boolean = (evt) => true): EventSourceProgress = {
+  def scroll(count: Int, decrementfn: (SparkListenerEvent) => Boolean = (evt) => true) = {
     require(count >= 0)
 
     var counter = count
@@ -165,8 +176,5 @@ private class ScrollHandler(movefn: () => SparkListenerEvent,
     while (counter > 0 && !breaker) {
       statefn(decrementIfMatch(movefn()))
     }
-
-    progress
   }
 }
-

--- a/src/main/scala/com/groupon/sparklint/events/FileEventSourceFactory.scala
+++ b/src/main/scala/com/groupon/sparklint/events/FileEventSourceFactory.scala
@@ -1,0 +1,34 @@
+package com.groupon.sparklint.events
+
+import java.io.File
+
+import com.groupon.sparklint.SparklintServer._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * An implementation of EventSourceFactory that constructs the EventSourceDetail instances from event source files.
+  *
+  * @author swhitear 
+  * @since 11/18/16.
+  */
+class FileEventSourceFactory extends EventSourceFactory[File] {
+
+  def buildEventSourceDetail(sourceFile: File): Option[EventSourceDetail] = {
+    var eventSourceDetail: EventSourceDetail = null
+    Try {
+      val progressReceiver = new EventSourceProgress()
+      val stateReceiver = new LosslessEventState()
+      val eventReceivers = Seq(progressReceiver, stateReceiver)
+      val eventSource = FileEventSource(sourceFile, eventReceivers)
+      eventSourceDetail = EventSourceDetail(eventSource, stateReceiver, progressReceiver)
+    } match {
+      case Success(eventSource) =>
+        logInfo(s"Successfully created file source ${sourceFile.getName}")
+        Some(eventSourceDetail)
+      case Failure(ex)          =>
+        logWarn(s"Failure creating file source from ${sourceFile.getName}: ${ex.getMessage}")
+        None
+    }
+  }
+}

--- a/src/main/scala/com/groupon/sparklint/events/FreeScrollEventSource.scala
+++ b/src/main/scala/com/groupon/sparklint/events/FreeScrollEventSource.scala
@@ -22,31 +22,36 @@ trait FreeScrollEventSource {
   self: EventSourceLike =>
 
   @throws[IllegalArgumentException]
-  def forwardEvents(count: Int = 1): EventSourceProgress
+  def forwardEvents(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def rewindEvents(count: Int = 1): EventSourceProgress
+  def rewindEvents(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def forwardTasks(count: Int = 1): EventSourceProgress
+  def forwardTasks(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def rewindTasks(count: Int = 1): EventSourceProgress
+  def rewindTasks(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def forwardStages(count: Int = 1): EventSourceProgress
+  def forwardStages(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def rewindStages(count: Int = 1): EventSourceProgress
+  def rewindStages(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def forwardJobs(count: Int = 1): EventSourceProgress
+  def forwardJobs(count: Int = 1): Unit
 
   @throws[IllegalArgumentException]
-  def rewindJobs(count: Int = 1): EventSourceProgress
+  def rewindJobs(count: Int = 1): Unit
 
-  def toEnd(): EventSourceProgress
+  def toEnd(): Unit
 
-  def toStart(): EventSourceProgress
+  def toStart(): Unit
+
+  def hasNext: Boolean
+
+  def hasPrevious: Boolean
+
 }
 

--- a/src/main/scala/com/groupon/sparklint/events/ListenerEventSourceFactory.scala
+++ b/src/main/scala/com/groupon/sparklint/events/ListenerEventSourceFactory.scala
@@ -1,0 +1,33 @@
+package com.groupon.sparklint.events
+
+import com.groupon.sparklint.SparklintServer._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * An implementation of EventSourceFactory that constructs the EventSourceDetail instances from live streams.
+  *
+  * @author swhitear
+  * @since 11/18/16.
+  */
+class ListenerEventSourceFactory extends EventSourceFactory[String] {
+
+  def buildEventSourceDetail(sourceId: String): Option[EventSourceDetail] = {
+    var eventSourceDetail: EventSourceDetail = null
+    Try {
+      val progressReceiver = new EventSourceProgress()
+      val stateReceiver = new CompressedEventState()
+      val eventReceivers = Seq(progressReceiver, stateReceiver)
+      val eventSource = BufferedEventSource(sourceId, eventReceivers)
+      eventSource.startConsuming()
+      eventSourceDetail = EventSourceDetail(eventSource, stateReceiver, progressReceiver)
+    } match {
+      case Success(eventSource) =>
+        logInfo(s"Successfully created buffered source $sourceId")
+        Some(eventSourceDetail)
+      case Failure(ex)          =>
+        logWarn(s"Failure creating buffered source from $sourceId: ${ex.getMessage}")
+        None
+    }
+  }
+}

--- a/src/main/scala/com/groupon/sparklint/events/LosslessEventState.scala
+++ b/src/main/scala/com/groupon/sparklint/events/LosslessEventState.scala
@@ -21,7 +21,7 @@ import org.apache.spark.scheduler._
   * @author rxue
   * @since 9/22/16.
   */
-class LosslessEventState(metricsBuckets: Int = 1000) extends EventStateLike with EventReceiverLike {
+class LosslessEventState(metricsBuckets: Int = 1000) extends EventStateLike {
 
   var state: LosslessState = LosslessState.empty
 

--- a/src/main/scala/com/groupon/sparklint/ui/SparklintHomepage.scala
+++ b/src/main/scala/com/groupon/sparklint/ui/SparklintHomepage.scala
@@ -56,7 +56,7 @@ class SparklintHomepage(sourceManager: EventSourceManagerLike) extends UITemplat
       <div class="navbar-default sidebar" role="navigation">
         <div class="sidebar-nav navbar-collapse">
           <ul class="nav" id="side-menu">
-            {for (source <- sourceManager.eventSource) yield navbarItem(source.source, source.progress)}
+            {for (source <- sourceManager.eventSources) yield navbarItem(source.source, source.progress)}
             {navbarReplayControl}
           </ul>
         </div>

--- a/src/main/scala/com/groupon/sparklint/ui/SparklintHomepage.scala
+++ b/src/main/scala/com/groupon/sparklint/ui/SparklintHomepage.scala
@@ -12,7 +12,7 @@
 */
 package com.groupon.sparklint.ui
 
-import com.groupon.sparklint.events.{EventSourceLike, EventSourceManagerLike, EventSourceProgress}
+import com.groupon.sparklint.events._
 
 import scala.xml.Node
 
@@ -56,24 +56,24 @@ class SparklintHomepage(sourceManager: EventSourceManagerLike) extends UITemplat
       <div class="navbar-default sidebar" role="navigation">
         <div class="sidebar-nav navbar-collapse">
           <ul class="nav" id="side-menu">
-            {for (app <- sourceManager.eventSources) yield navbarItem(app)}
+            {for (source <- sourceManager.eventSource) yield navbarItem(source.source, source.progress)}
             {navbarReplayControl}
           </ul>
         </div>
       </div>
     </nav>
 
-  def navbarItem(app: EventSourceLike): Seq[Node] =
-    <li data-value={app.appId}>
-      <a href="#" class="sparklintApp" data-value={app.appId}>
-        <strong>App: </strong>{app.nameOrId}
-        <p class="text-center" id={uniqueId(app.appId, "app-prog")}>
-        {app.progress.description}
+  def navbarItem(source: EventSourceLike, progress: EventSourceProgressLike): Seq[Node] =
+    <li data-value={source.appId}>
+      <a href="#" class="sparklintApp" data-value={source.appId}>
+        <strong>App: </strong>{source.nameOrId}
+        <p class="text-center" id={uniqueId(source.appId, "app-prog")}>
+        {progress.eventProgress.description}
       </p>
         <div class="progress active">
-          <div class="progress-bar" role="progressbar" id={uniqueId(app.appId, "progress-bar")}
-               aria-valuenow={app.progress.percent.toString} aria-valuemin="0" aria-valuemax="100"
-               style={widthStyle(app.progress)}>
+          <div class="progress-bar" role="progressbar" id={uniqueId(source.appId, "progress-bar")}
+               aria-valuenow={progress.eventProgress.percent.toString} aria-valuemin="0" aria-valuemax="100"
+               style={widthStyle(progress.eventProgress)}>
           </div>
         </div>
       </a>
@@ -103,7 +103,7 @@ class SparklintHomepage(sourceManager: EventSourceManagerLike) extends UITemplat
           <option>1000</option>
         </select>
         <select class="form-control" id="typeSelector">
-          {for (navType <- UIServer.supportedNavTypes) yield
+          {for (navType <- EventType.ALL_TYPES) yield
           <option>{navType}</option>
           }
         </select>
@@ -288,7 +288,7 @@ class SparklintHomepage(sourceManager: EventSourceManagerLike) extends UITemplat
       <!-- /.panel-body -->
     </div>
 
-  private def widthStyle(esp: EventSourceProgress) = s"width: ${esp.percent}%"
+  private def widthStyle(esp: EventProgressLike) = s"width: ${esp.percent}%"
 
   private def uniqueId(appId: String, idType: String) = s"$appId-$idType"
 }

--- a/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
+++ b/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
@@ -14,9 +14,9 @@ package com.groupon.sparklint.ui
 
 import com.groupon.sparklint.analyzer.SparklintStateAnalyzer
 import com.groupon.sparklint.common.Logging
-import com.groupon.sparklint.events.{EventSourceLike, EventSourceManagerLike, EventSourceProgress}
+import com.groupon.sparklint.events._
 import com.groupon.sparklint.server.{AdhocServer, StaticFileService}
-import org.http4s.dsl._
+import org.http4s.dsl.{->, /, _}
 import org.http4s.{HttpService, Response}
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
@@ -37,13 +37,13 @@ class UIServer(esManager: EventSourceManagerLike)
   routingMap("/") = sparklintService
 
   private def sparklintService = HttpService {
-    case GET -> Root                                                          => homepageHtml
-    case GET -> Root / appId / "state" if appExists(appId)                    => progressJson(appId)
-    case GET -> Root / appId / "eventSource" if appExists(appId)              => eventSourceJson(appId)
-    case GET -> Root / appId / "forward" / count / evType if appExists(appId) => forwardAppJson(appId, count, evType)
-    case GET -> Root / appId / "rewind" / count / evType if appExists(appId)  => rewindAppJson(appId, count, evType)
-    case GET -> Root / appId / "to_end" if appExists(appId)                   => endAppJson(appId)
-    case GET -> Root / appId / "to_start" if appExists(appId)                 => startAppJson(appId)
+    case GET -> Root                                                            => homepageHtml
+    case GET -> Root / appId / "state" if appExists(appId)                      => progressJson(appId)
+    case GET -> Root / appId / "eventSource" if appExists(appId)                => eventSourceJson(appId)
+    case GET -> Root / appId / "forward" / count / evString if appExists(appId) => fwdAppJson(appId, count, evString)
+    case GET -> Root / appId / "rewind" / count / evString if appExists(appId)  => rwdAppJson(appId, count, evString)
+    case GET -> Root / appId / "to_end" if appExists(appId)                     => endAppJson(appId)
+    case GET -> Root / appId / "to_start" if appExists(appId)                   => startAppJson(appId)
   }
 
   private def appExists(appId: String) = {
@@ -56,79 +56,92 @@ class UIServer(esManager: EventSourceManagerLike)
   }
 
   private def progressJson(appId: String) = {
-    val es = esManager.getSource(appId)
-    val report = SparklintStateAnalyzer(es)
-    jsonResponse(Ok(pretty(UIServer.reportJson(report, es))))
+    val detail = esManager.getSourceDetail(appId)
+    val report = SparklintStateAnalyzer(detail.source, detail.state)
+    jsonResponse(Ok(pretty(UIServer.reportJson(report, detail.source, detail.progress))))
   }
 
   private def eventSourceJson(appId: String) = {
-    jsonResponse(Ok(pretty(UIServer.progressJson(esManager.getSource(appId).progress))))
+    jsonResponse(Ok(pretty(UIServer.progressJson(esManager.getSourceDetail(appId).progress))))
   }
 
-  private def forwardAppJson(appId: String, count: String, evType: String) = evType.toLowerCase match {
-    case `eventsNav` => moveEventSource(count, appId)(esManager.getScrollingSource(appId).forwardEvents)
-    case `tasksNav`  => moveEventSource(count, appId)(esManager.getScrollingSource(appId).forwardTasks)
-    case `stagesNav` => moveEventSource(count, appId)(esManager.getScrollingSource(appId).forwardStages)
-    case `jobsNav`   => moveEventSource(count, appId)(esManager.getScrollingSource(appId).forwardJobs)
+  private def fwdAppJson(appId: String, count: String, evString: String): Task[Response] = {
+    fwdAppJson(appId, count, EventType.fromString(evString))
+
   }
 
-  private def rewindAppJson(appId: String, count: String, evType: String) = evType.toLowerCase match {
-    case `eventsNav` => moveEventSource(count, appId)(esManager.getScrollingSource(appId).rewindEvents)
-    case `tasksNav`  => moveEventSource(count, appId)(esManager.getScrollingSource(appId).rewindTasks)
-    case `stagesNav` => moveEventSource(count, appId)(esManager.getScrollingSource(appId).rewindStages)
-    case `jobsNav`   => moveEventSource(count, appId)(esManager.getScrollingSource(appId).rewindJobs)
+  private def fwdAppJson(appId: String, count: String, evType: EventType): Task[Response] = {
+    def progress() = esManager.getSourceDetail(appId).progress
+    val mover = moveEventSource(count, appId, progress) _
+    evType match {
+      case Events() => mover(esManager.getScrollingSource(appId).forwardEvents)
+      case Tasks()  => mover(esManager.getScrollingSource(appId).forwardTasks)
+      case Stages() => mover(esManager.getScrollingSource(appId).forwardStages)
+      case Jobs()   => mover(esManager.getScrollingSource(appId).forwardJobs)
+    }
+  }
+
+  private def rwdAppJson(appId: String, count: String, evString: String): Task[Response] = {
+    rwdAppJson(appId, count, EventType.fromString(evString))
+
+  }
+
+  private def rwdAppJson(appId: String, count: String, evType: EventType): Task[Response] = {
+    def progress() = esManager.getSourceDetail(appId).progress
+    val mover = moveEventSource(count, appId, progress) _
+    evType match {
+      case Events() => mover(esManager.getScrollingSource(appId).rewindEvents)
+      case Tasks()  => mover(esManager.getScrollingSource(appId).rewindTasks)
+      case Stages() => mover(esManager.getScrollingSource(appId).rewindStages)
+      case Jobs()   => mover(esManager.getScrollingSource(appId).rewindJobs)
+    }
   }
 
   private def endAppJson(appId: String) = {
-    endOfEventSource(appId)(esManager.getScrollingSource(appId).toEnd)
+    endOfEventSource(appId,
+      (appid) => esManager.getScrollingSource(appid).toEnd(),
+      (appid) => esManager.getSourceDetail(appid).progress)
   }
 
   private def startAppJson(appId: String) = {
-    endOfEventSource(appId)(esManager.getScrollingSource(appId).toStart)
+    endOfEventSource(appId,
+      (appid) => esManager.getScrollingSource(appId).toStart(),
+      (appid) => esManager.getSourceDetail(appid).progress)
   }
 
-  private def moveEventSource(count: String, appId: String)(fx: (Int) => EventSourceProgress): Task[Response] = {
-    Try(fx(count.toInt)) match {
+  private def moveEventSource(count: String, appId: String, progFn: () => EventSourceProgressLike)
+                             (moveFn: (Int) => Unit): Task[Response] = {
+    Try(moveFn(count.toInt)) match {
       case Success(progress) =>
-        jsonResponse(Ok(pretty(UIServer.progressJson(progress))))
+        jsonResponse(Ok(pretty(UIServer.progressJson(progFn()))))
       case Failure(ex)       =>
         logError(s"Failure to move appId $appId: ${ex.getMessage}")
         eventSourceJson(appId)
     }
   }
 
-  private def endOfEventSource(appId: String)(fx: () => EventSourceProgress): Task[Response] = {
-    Try(fx()) match {
-      case Success(progress) =>
-        jsonResponse(Ok(pretty(UIServer.progressJson(progress))))
-      case Failure(ex)       =>
+  private def endOfEventSource(appId: String,
+                               moveFn: (String) => Unit,
+                               progFn: (String) => EventSourceProgressLike): Task[Response] = {
+    Try(moveFn(appId)) match {
+      case Success(unit) =>
+        jsonResponse(Ok(pretty(UIServer.progressJson(progFn(appId)))))
+      case Failure(ex)   =>
         logError(s"Failure to end of appId $appId: ${ex.getMessage}")
         eventSourceJson(appId)
     }
   }
-
-  private val eventsNav = UIServer.NAV_TYPE_EVENTS.toLowerCase
-  private val tasksNav  = UIServer.NAV_TYPE_TASKS.toLowerCase
-  private val stagesNav = UIServer.NAV_TYPE_STAGES.toLowerCase
-  private val jobsNav   = UIServer.NAV_TYPE_JOBS.toLowerCase
 }
 
 object UIServer {
 
-  val NAV_TYPE_EVENTS = "Events"
-  val NAV_TYPE_TASKS  = "Tasks"
-  val NAV_TYPE_STAGES = "Stages"
-  val NAV_TYPE_JOBS   = "Jobs"
-
-  def supportedNavTypes: Seq[String] = Seq(NAV_TYPE_EVENTS, NAV_TYPE_TASKS, NAV_TYPE_STAGES, NAV_TYPE_JOBS)
-
-  def reportJson(report: SparklintStateAnalyzer, es: EventSourceLike): JObject = {
+  def reportJson(report: SparklintStateAnalyzer,
+                 source: EventSourceLike,
+                 progress: EventSourceProgressLike): JObject = {
     implicit val formats = DefaultFormats
 
-    val progress = es.progress
-
-    ("appName" -> es.appName) ~
-      ("appId" -> es.appId) ~
+    ("appName" -> source.appName) ~
+      ("appId" -> source.appId) ~
       ("allocatedCores" -> report.getExecutorInfo.map(_.values.map(_.cores).sum)) ~
       ("executors" -> report.getExecutorInfo.map(_.map({ case (executorId, info) =>
         ("executorId" -> executorId) ~
@@ -163,15 +176,15 @@ object UIServer {
       ("maxCoreUsage" -> report.getMaxCoreUsage) ~
       ("coreUtilizationPercentage" -> report.getCoreUtilizationPercentage) ~
       ("lastUpdatedAt" -> report.getLastUpdatedAt) ~
-      ("applicationLaunchedAt" -> es.startTime) ~
-      ("applicationEndedAt" -> es.endTime) ~
+      ("applicationLaunchedAt" -> source.startTime) ~
+      ("applicationEndedAt" -> source.endTime) ~
       ("progress" -> progressJson(progress))
   }
 
-  def progressJson(progress: EventSourceProgress) = {
-    ("percent" -> progress.percent) ~
-      ("description" -> progress.description) ~
-      ("has_next" -> progress.hasNext) ~
-      ("has_previous" -> progress.hasPrevious)
+  def progressJson(progress: EventSourceProgressLike) = {
+    ("percent" -> progress.eventProgress.percent) ~
+      ("description" -> progress.eventProgress.description) ~
+      ("has_next" -> progress.eventProgress.hasNext) ~
+      ("has_previous" -> progress.eventProgress.hasPrevious)
   }
 }

--- a/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
+++ b/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
@@ -68,13 +68,13 @@ class UIServer(esManager: EventSourceManagerLike)
   }
 
   private def progress(appId: String): String = {
-    val detail = esManager.getSourceDetail(appId)
+    val detail = esManager.getSource(appId)
     val report = SparklintStateAnalyzer(detail.source, detail.state)
     pretty(UIServer.reportJson(report, detail.source, detail.progress))
   }
 
   private def eventSource(appId: String): String = {
-    pretty(UIServer.progressJson(esManager.getSourceDetail(appId).progress))
+    pretty(UIServer.progressJson(esManager.getSource(appId).progress))
   }
 
   private def fwdApp(appId: String, count: String, evString: String): String = {
@@ -82,7 +82,7 @@ class UIServer(esManager: EventSourceManagerLike)
   }
 
   private def fwdApp(appId: String, count: String, evType: EventType): String = {
-    def progress() = esManager.getSourceDetail(appId).progress
+    def progress() = esManager.getSource(appId).progress
     val mover = moveEventSource(count, appId, progress) _
     evType match {
       case Events() => mover(esManager.getScrollingSource(appId).forwardEvents)
@@ -97,7 +97,7 @@ class UIServer(esManager: EventSourceManagerLike)
   }
 
   private def rwdApp(appId: String, count: String, evType: EventType): String = {
-    def progress() = esManager.getSourceDetail(appId).progress
+    def progress() = esManager.getSource(appId).progress
     val mover = moveEventSource(count, appId, progress) _
     evType match {
       case Events() => mover(esManager.getScrollingSource(appId).rewindEvents)
@@ -110,13 +110,13 @@ class UIServer(esManager: EventSourceManagerLike)
   private def endApp(appId: String): String = {
     endOfEventSource(appId,
       (appid) => esManager.getScrollingSource(appid).toEnd(),
-      (appid) => esManager.getSourceDetail(appid).progress)
+      (appid) => esManager.getSource(appid).progress)
   }
 
   private def startApp(appId: String): String = {
     endOfEventSource(appId,
       (appid) => esManager.getScrollingSource(appId).toStart(),
-      (appid) => esManager.getSourceDetail(appid).progress)
+      (appid) => esManager.getSource(appid).progress)
   }
 
   private def moveEventSource(count: String, appId: String, progFn: () => EventSourceProgressLike)

--- a/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
@@ -57,10 +57,10 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSource.size shouldEqual 1
+    eventSourceManager.eventSources.size shouldEqual 1
     scheduler.scheduledTasks.isEmpty shouldBe true
 
-    val es = eventSourceManager.eventSource.head
+    val es = eventSourceManager.eventSources.head
     es.source.appId shouldEqual "application_1462781278026_205691"
     es.progress.eventProgress.hasNext shouldEqual true
     es.progress.eventProgress.hasPrevious shouldEqual false
@@ -73,10 +73,10 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSource.size shouldEqual 1
+    eventSourceManager.eventSources.size shouldEqual 1
     scheduler.scheduledTasks.isEmpty shouldBe true
 
-    val es = eventSourceManager.eventSource.head
+    val es = eventSourceManager.eventSources.head
     es.source.appId shouldEqual "application_1462781278026_205691"
     es.progress.eventProgress.hasNext shouldEqual false
     es.progress.eventProgress.hasPrevious shouldEqual true
@@ -90,19 +90,19 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSource.size shouldEqual 0
+    eventSourceManager.eventSources.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 2
+    eventSourceManager.eventSources.size shouldEqual 2
 
-    var es = eventSourceManager.eventSource.filter(_.source.appId == "application_1462781278026_205691").head
+    var es = eventSourceManager.eventSources.filter(_.source.appId == "application_1462781278026_205691").head
     es.source.appId shouldEqual "application_1462781278026_205691"
     es.progress.eventProgress.hasNext shouldEqual true
     es.progress.eventProgress.hasPrevious shouldEqual false
 
-    es = eventSourceManager.eventSource.filter(_.source.appId == "application_1472176676028_116806").head
+    es = eventSourceManager.eventSources.filter(_.source.appId == "application_1472176676028_116806").head
     es.source.appId shouldEqual "application_1472176676028_116806"
     es.progress.eventProgress.hasNext shouldEqual true
     es.progress.eventProgress.hasPrevious shouldEqual false
@@ -114,19 +114,19 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSource.size shouldEqual 0
+    eventSourceManager.eventSources.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 2
+    eventSourceManager.eventSources.size shouldEqual 2
 
-    var es = eventSourceManager.eventSource.filter(_.source.appId == "application_1462781278026_205691").head
+    var es = eventSourceManager.eventSources.filter(_.source.appId == "application_1462781278026_205691").head
     es.source.appId shouldEqual "application_1462781278026_205691"
     es.progress.eventProgress.hasNext shouldEqual false
     es.progress.eventProgress.hasPrevious shouldEqual true
 
-    es = eventSourceManager.eventSource.filter(_.source.appId == "application_1472176676028_116806").head
+    es = eventSourceManager.eventSources.filter(_.source.appId == "application_1472176676028_116806").head
     es.source.appId shouldEqual "application_1472176676028_116806"
     es.progress.eventProgress.hasNext shouldEqual false
     es.progress.eventProgress.hasPrevious shouldEqual true
@@ -138,26 +138,26 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSource.size shouldEqual 0
+    eventSourceManager.eventSources.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 2
+    eventSourceManager.eventSources.size shouldEqual 2
 
-    eventSourceManager.eventSource.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
-    eventSourceManager.eventSource.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
+    eventSourceManager.eventSources.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
+    eventSourceManager.eventSources.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
 
     // add a new file to the directory
     addInTempFile(tempFile)
 
-    eventSourceManager.eventSource.size shouldEqual 2
+    eventSourceManager.eventSources.size shouldEqual 2
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 3
+    eventSourceManager.eventSources.size shouldEqual 3
 
-    eventSourceManager.eventSource.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
-    eventSourceManager.eventSource.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
-    eventSourceManager.eventSource.count(_.source.appId == "temp_addded_in_test") shouldEqual 1
+    eventSourceManager.eventSources.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
+    eventSourceManager.eventSources.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
+    eventSourceManager.eventSources.count(_.source.appId == "temp_addded_in_test") shouldEqual 1
 
     // cleanup again
     cleanupTempFile(tempFile)
@@ -171,15 +171,15 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 2
+    eventSourceManager.eventSources.size shouldEqual 2
 
     // add a new file to the directory
     addInTempFile(tempFile)
 
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSource.size shouldEqual 3
+    eventSourceManager.eventSources.size shouldEqual 3
 
-    val es = eventSourceManager.eventSource.filter(_.source.appId == "temp_addded_in_test").head
+    val es = eventSourceManager.eventSources.filter(_.source.appId == "temp_addded_in_test").head
     es.source.appId shouldEqual "temp_addded_in_test"
     es.progress.eventProgress.hasNext shouldEqual false
     es.progress.eventProgress.hasPrevious shouldEqual true
@@ -206,23 +206,20 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
   }
 }
 
-case class StubEventSourceManager(eventSource: ArrayBuffer[EventSourceDetail] = ArrayBuffer[EventSourceDetail]())
+case class StubEventSourceManager(eventSources: ArrayBuffer[EventSourceDetail] = ArrayBuffer[EventSourceDetail]())
   extends EventSourceManagerLike {
 
-  override def addEventSource(eventDetail: EventSourceDetail): Unit = eventSource += eventDetail
+  override def addEventSource(eventDetail: EventSourceDetail): Unit = eventSources += eventDetail
 
-  override def sourceCount: Int = eventSource.size
+  override def sourceCount: Int = eventSources.size
 
-  override def containsAppId(appId: String): Boolean = eventSource.exists(_.source.appId == appId)
+  override def containsAppId(appId: String): Boolean = eventSources.exists(_.source.appId == appId)
 
   @throws[NoSuchElementException]
-  override def getSource(appId: String): EventSourceLike = ???
+  override def getSource(appId: String): EventSourceDetail = ???
 
   @throws[NoSuchElementException]
   override def getScrollingSource(appId: String): FreeScrollEventSource = ???
-
-  @throws[NoSuchElementException]
-  override def getSourceDetail(appId: String): EventSourceDetail = ???
 }
 
 case class StubScheduler(scheduledTasks: ArrayBuffer[ScheduledTask[_]] = ArrayBuffer[ScheduledTask[_]]())

--- a/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
@@ -16,7 +16,7 @@ import java.io.File
 
 import com.groupon.sparklint.TestUtils.resource
 import com.groupon.sparklint.common.{ScheduledTask, SchedulerLike, SparklintConfig}
-import com.groupon.sparklint.events.{EventSourceLike, EventSourceManagerLike, FreeScrollEventSource}
+import com.groupon.sparklint.events.{EventSourceDetail, EventSourceLike, EventSourceManagerLike, FreeScrollEventSource}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
@@ -57,13 +57,13 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSources.size shouldEqual 1
+    eventSourceManager.eventSource.size shouldEqual 1
     scheduler.scheduledTasks.isEmpty shouldBe true
 
-    val es = eventSourceManager.eventSources.head
-    es.appId shouldEqual "application_1462781278026_205691"
-    es.progress.hasNext shouldEqual true
-    es.progress.hasPrevious shouldEqual false
+    val es = eventSourceManager.eventSource.head
+    es.source.appId shouldEqual "application_1462781278026_205691"
+    es.progress.eventProgress.hasNext shouldEqual true
+    es.progress.eventProgress.hasPrevious shouldEqual false
   }
 
   it should "load expected buffer from a file and replay when configured" in {
@@ -73,13 +73,13 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSources.size shouldEqual 1
+    eventSourceManager.eventSource.size shouldEqual 1
     scheduler.scheduledTasks.isEmpty shouldBe true
 
-    val es = eventSourceManager.eventSources.head
-    es.appId shouldEqual "application_1462781278026_205691"
-    es.progress.hasNext shouldEqual false
-    es.progress.hasPrevious shouldEqual true
+    val es = eventSourceManager.eventSource.head
+    es.source.appId shouldEqual "application_1462781278026_205691"
+    es.progress.eventProgress.hasNext shouldEqual false
+    es.progress.eventProgress.hasPrevious shouldEqual true
   }
 
 
@@ -90,22 +90,22 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSources.size shouldEqual 0
+    eventSourceManager.eventSource.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 2
+    eventSourceManager.eventSource.size shouldEqual 2
 
-    var es = eventSourceManager.eventSources.filter(_.appId == "application_1462781278026_205691").head
-    es.appId shouldEqual "application_1462781278026_205691"
-    es.progress.hasNext shouldEqual true
-    es.progress.hasPrevious shouldEqual false
+    var es = eventSourceManager.eventSource.filter(_.source.appId == "application_1462781278026_205691").head
+    es.source.appId shouldEqual "application_1462781278026_205691"
+    es.progress.eventProgress.hasNext shouldEqual true
+    es.progress.eventProgress.hasPrevious shouldEqual false
 
-    es = eventSourceManager.eventSources.filter(_.appId == "application_1472176676028_116806").head
-    es.appId shouldEqual "application_1472176676028_116806"
-    es.progress.hasNext shouldEqual true
-    es.progress.hasPrevious shouldEqual false
+    es = eventSourceManager.eventSource.filter(_.source.appId == "application_1472176676028_116806").head
+    es.source.appId shouldEqual "application_1472176676028_116806"
+    es.progress.eventProgress.hasNext shouldEqual true
+    es.progress.eventProgress.hasPrevious shouldEqual false
   }
 
   it should "load expected buffer from a directory and replay when configured" in {
@@ -114,22 +114,22 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSources.size shouldEqual 0
+    eventSourceManager.eventSource.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 2
+    eventSourceManager.eventSource.size shouldEqual 2
 
-    var es = eventSourceManager.eventSources.filter(_.appId == "application_1462781278026_205691").head
-    es.appId shouldEqual "application_1462781278026_205691"
-    es.progress.hasNext shouldEqual false
-    es.progress.hasPrevious shouldEqual true
+    var es = eventSourceManager.eventSource.filter(_.source.appId == "application_1462781278026_205691").head
+    es.source.appId shouldEqual "application_1462781278026_205691"
+    es.progress.eventProgress.hasNext shouldEqual false
+    es.progress.eventProgress.hasPrevious shouldEqual true
 
-    es = eventSourceManager.eventSources.filter(_.appId == "application_1472176676028_116806").head
-    es.appId shouldEqual "application_1472176676028_116806"
-    es.progress.hasNext shouldEqual false
-    es.progress.hasPrevious shouldEqual true
+    es = eventSourceManager.eventSource.filter(_.source.appId == "application_1472176676028_116806").head
+    es.source.appId shouldEqual "application_1472176676028_116806"
+    es.progress.eventProgress.hasNext shouldEqual false
+    es.progress.eventProgress.hasPrevious shouldEqual true
   }
 
   it should "refresh with the latest new files when task fired" in {
@@ -138,26 +138,26 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
     server.buildEventSources()
     server.run()
 
-    eventSourceManager.eventSources.size shouldEqual 0
+    eventSourceManager.eventSource.size shouldEqual 0
     scheduler.scheduledTasks.size shouldEqual 1
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 2
+    eventSourceManager.eventSource.size shouldEqual 2
 
-    eventSourceManager.eventSources.count(_.appId == "application_1462781278026_205691") shouldEqual 1
-    eventSourceManager.eventSources.count(_.appId == "application_1472176676028_116806") shouldEqual 1
+    eventSourceManager.eventSource.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
+    eventSourceManager.eventSource.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
 
     // add a new file to the directory
     addInTempFile(tempFile)
 
-    eventSourceManager.eventSources.size shouldEqual 2
+    eventSourceManager.eventSource.size shouldEqual 2
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 3
+    eventSourceManager.eventSource.size shouldEqual 3
 
-    eventSourceManager.eventSources.count(_.appId == "application_1462781278026_205691") shouldEqual 1
-    eventSourceManager.eventSources.count(_.appId == "application_1472176676028_116806") shouldEqual 1
-    eventSourceManager.eventSources.count(_.appId == "temp_addded_in_test") shouldEqual 1
+    eventSourceManager.eventSource.count(_.source.appId == "application_1462781278026_205691") shouldEqual 1
+    eventSourceManager.eventSource.count(_.source.appId == "application_1472176676028_116806") shouldEqual 1
+    eventSourceManager.eventSource.count(_.source.appId == "temp_addded_in_test") shouldEqual 1
 
     // cleanup again
     cleanupTempFile(tempFile)
@@ -171,18 +171,18 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
 
     // fire the timed event to load from directory
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 2
+    eventSourceManager.eventSource.size shouldEqual 2
 
     // add a new file to the directory
     addInTempFile(tempFile)
 
     scheduler.scheduledTasks.head.run()
-    eventSourceManager.eventSources.size shouldEqual 3
+    eventSourceManager.eventSource.size shouldEqual 3
 
-    val es = eventSourceManager.eventSources.filter(_.appId == "temp_addded_in_test").head
-    es.appId shouldEqual "temp_addded_in_test"
-    es.progress.hasNext shouldEqual false
-    es.progress.hasPrevious shouldEqual true
+    val es = eventSourceManager.eventSource.filter(_.source.appId == "temp_addded_in_test").head
+    es.source.appId shouldEqual "temp_addded_in_test"
+    es.progress.eventProgress.hasNext shouldEqual false
+    es.progress.eventProgress.hasPrevious shouldEqual true
 
     // cleanup again
     cleanupTempFile(tempFile)
@@ -206,20 +206,23 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
   }
 }
 
-case class StubEventSourceManager(eventSources: ArrayBuffer[EventSourceLike] = ArrayBuffer[EventSourceLike]())
+case class StubEventSourceManager(eventSource: ArrayBuffer[EventSourceDetail] = ArrayBuffer[EventSourceDetail]())
   extends EventSourceManagerLike {
 
-  override def addEventSource(eventSource: EventSourceLike): Unit = eventSources += eventSource
+  override def addEventSource(eventDetail: EventSourceDetail): Unit = eventSource += eventDetail
 
-  override def sourceCount: Int = eventSources.size
+  override def sourceCount: Int = eventSource.size
 
-  override def containsAppId(appId: String): Boolean = eventSources.exists(_.appId == appId)
+  override def containsAppId(appId: String): Boolean = eventSource.exists(_.source.appId == appId)
 
   @throws[NoSuchElementException]
   override def getSource(appId: String): EventSourceLike = ???
 
   @throws[NoSuchElementException]
   override def getScrollingSource(appId: String): FreeScrollEventSource = ???
+
+  @throws[NoSuchElementException]
+  override def getSourceDetail(appId: String): EventSourceDetail = ???
 }
 
 case class StubScheduler(scheduledTasks: ArrayBuffer[ScheduledTask[_]] = ArrayBuffer[ScheduledTask[_]]())

--- a/src/test/scala/com/groupon/sparklint/TestUtils.scala
+++ b/src/test/scala/com/groupon/sparklint/TestUtils.scala
@@ -54,11 +54,11 @@ object TestUtils {
   }
 
   def stubEventDetails(appId: String): EventSourceDetail = {
-    EventSourceDetail(StubEventSource(appId), EventSourceProgress(), StubEventState())
+    EventSourceDetail(StubEventSource(appId), StubEventState(), new EventSourceProgress())
   }
 
   def stubEventDetails(eventSource: EventSourceLike): EventSourceDetail = {
-    EventSourceDetail(eventSource, EventSourceProgress(), StubEventState())
+    EventSourceDetail(eventSource, StubEventState(), new EventSourceProgress())
   }
 
   def sparkAppStart(name: String = TEST_NAME,

--- a/src/test/scala/com/groupon/sparklint/TestUtils.scala
+++ b/src/test/scala/com/groupon/sparklint/TestUtils.scala
@@ -12,8 +12,15 @@
 */
 package com.groupon.sparklint
 
-import com.groupon.sparklint.events.{EventSourceLike, FreeScrollEventSource}
-import org.apache.spark.scheduler.{SparkListenerEvent, SparkListenerStageSubmitted, StageInfo}
+import java.util.Properties
+
+import com.groupon.sparklint.events.{StubEventSource, _}
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.scheduler._
+import org.apache.spark.storage.RDDInfo
+import org.apache.spark.{Success, TaskEndReason}
+
+import scala.collection.Map
 
 /**
   * @author rxue
@@ -21,15 +28,23 @@ import org.apache.spark.scheduler.{SparkListenerEvent, SparkListenerStageSubmitt
   */
 object TestUtils {
 
+  val TEST_TIME_LONG   = 42l
+  val TEST_NAME        = "test-name"
+  val TEST_APP_ID      = "test-app-id"
+  val TEST_EXECUTOR_ID = "test-executor"
+  val TEST_HOST        = "test-host"
+  val TEST_TASK_TYPE   = "test-task-type"
+  val TEST_USER        = "test-user"
+  val TEST_DETAILS     = "test-details"
+
   def resource(name: String): String = {
     ResourceHelper.convertResourcePathToFilePath(getClass.getClassLoader, name)
   }
 
   def replay(eventSource: EventSourceLike with FreeScrollEventSource, count: Long = Long.MaxValue) = {
     var counter = 0
-    var progress = eventSource.progress
-    while (counter < count && progress.hasNext) {
-      progress = eventSource.forwardEvents()
+    while (counter < count && eventSource.hasNext) {
+      eventSource.forwardEvents()
       counter += 1
     }
   }
@@ -37,6 +52,106 @@ object TestUtils {
   def sparkStageSubmittedEvent(id: Int, name: String): SparkListenerEvent = {
     SparkListenerStageSubmitted(new StageInfo(id, 42, name, 42, Seq.empty, Seq.empty, "details"))
   }
+
+  def stubEventDetails(appId: String): EventSourceDetail = {
+    EventSourceDetail(StubEventSource(appId), EventSourceProgress(), StubEventState())
+  }
+
+  def stubEventDetails(eventSource: EventSourceLike): EventSourceDetail = {
+    EventSourceDetail(eventSource, EventSourceProgress(), StubEventState())
+  }
+
+  def sparkAppStart(name: String = TEST_NAME,
+                    appId: String = TEST_APP_ID,
+                    time: Long = TEST_TIME_LONG,
+                    user: String = TEST_USER,
+                    attemptId: Option[String] = None,
+                    driverLogs: Option[Map[String, String]] = None): SparkListenerApplicationStart = {
+    SparkListenerApplicationStart(name, Some(appId), time, user, attemptId, driverLogs)
+  }
+
+  def sparkTaskStartEventFromId(taskId: Long): SparkListenerTaskStart = {
+    sparkTaskStartEvent(taskId = taskId)()
+  }
+
+  def sparkTaskStartEvent(taskId: Long = 0,
+                          stageId: Int = 0,
+                          stageAttempt: Int = 0)
+                         (taskInfo: TaskInfo = sparkTaskInfo(taskId)): SparkListenerTaskStart = {
+    SparkListenerTaskStart(stageId, stageAttempt, taskInfo)
+  }
+
+  def sparkTaskEndEventFromId(taskId: Long): SparkListenerTaskEnd = {
+    sparkTaskEndEvent(taskId = taskId)()
+  }
+
+  def sparkTaskEndEvent(taskId: Long = 0,
+                        stageId: Int = 0,
+                        stageAttempt: Int = 0,
+                        taskType: String = TEST_TASK_TYPE,
+                        taskEndReason: TaskEndReason = Success)
+                       (taskInfo: TaskInfo = sparkTaskInfo(taskId),
+                        taskMetrics: TaskMetrics = sparkTaskMetrics()): SparkListenerTaskEnd = {
+    SparkListenerTaskEnd(stageId, stageAttempt, taskType, taskEndReason, taskInfo, taskMetrics)
+  }
+
+  def sparkTaskInfo(taskId: Long = 0,
+                    index: Int = 0,
+                    attempt: Int = 0,
+                    launchTime: Long = TEST_TIME_LONG,
+                    executorId: String = TEST_EXECUTOR_ID,
+                    host: String = TEST_HOST,
+                    locality: TaskLocality.TaskLocality = TaskLocality.NO_PREF): TaskInfo = {
+    new TaskInfo(taskId, index, attempt, launchTime, executorId, host, locality, false)
+  }
+
+  def sparkTaskMetrics(): TaskMetrics = new TaskMetrics
+
+  def sparkStageCompletedFromId(stageId: Int): SparkListenerStageCompleted = {
+    sparkStageCompleted(sparkStageInfo(stageId = stageId))
+  }
+
+  def sparkStageCompleted(stageInfo: StageInfo = sparkStageInfo()): SparkListenerStageCompleted = {
+    SparkListenerStageCompleted(stageInfo)
+  }
+
+  def sparkStageSubmittedFromId(stageId: Int): SparkListenerStageSubmitted = {
+    sparkStageSubmitted(sparkStageInfo(stageId = stageId))
+  }
+
+  def sparkStageSubmitted(stageInfo: StageInfo = sparkStageInfo(),
+                          properties: Properties = new Properties()): SparkListenerStageSubmitted = {
+    SparkListenerStageSubmitted(stageInfo)
+  }
+
+  def sparkStageInfo(stageId: Int = 0,
+                     attempt: Int = 0,
+                     name: String = TEST_NAME,
+                     numTasks: Int = 0,
+                     rddInfo: Seq[RDDInfo] = Seq.empty,
+                     parentIds: Seq[Int] = Seq.empty,
+                     details: String = TEST_DETAILS): StageInfo = {
+    new StageInfo(stageId, attempt, name, numTasks, rddInfo, parentIds, details)
+  }
+
+  def sparkJobStartFromId(jobId: Int): SparkListenerJobStart = {
+    sparkJobStart(jobId = jobId)
+  }
+
+  def sparkJobStart(jobId: Int = 0,
+                    time: Long = TEST_TIME_LONG,
+                    stageInfos: Seq[StageInfo] = Seq.empty,
+                    properties: Properties = new Properties()): SparkListenerJobStart = {
+    SparkListenerJobStart(jobId, time, stageInfos, properties)
+  }
+
+  def sparkJobEndFromId(jobId: Int): SparkListenerJobEnd = {
+    sparkJobEnd(jobId = jobId)
+  }
+
+  def sparkJobEnd(jobId: Int = 0,
+                  time: Long = TEST_TIME_LONG,
+                  jobResult: JobResult = JobSucceeded): SparkListenerJobEnd = {
+    SparkListenerJobEnd(jobId, time, jobResult)
+  }
 }
-
-

--- a/src/test/scala/com/groupon/sparklint/analyzer/EventSourceManagerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/analyzer/EventSourceManagerTest.scala
@@ -12,8 +12,7 @@
 */
 package com.groupon.sparklint.analyzer
 
-import com.groupon.sparklint.data.SparklintStateLike
-import com.groupon.sparklint.data.compressed.CompressedState
+import com.groupon.sparklint.TestUtils._
 import com.groupon.sparklint.events._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -27,92 +26,39 @@ class EventSourceManagerTest extends FlatSpec with Matchers {
     val manager = new EventSourceManager()
 
     manager.sourceCount shouldEqual 0
-    manager.eventSources.isEmpty shouldBe true
+    manager.eventSource.isEmpty shouldBe true
   }
 
   it should "initialize with start state if initial sources supplied" in {
-    val evSource = StubEventSource("test_app_id")
-    val manager = new EventSourceManager(evSource)
+    val evDetail = stubEventDetails("test_app_id")
+    val manager = new EventSourceManager(evDetail)
 
     manager.sourceCount shouldEqual 1
-    manager.eventSources.head shouldBe evSource
+    manager.eventSource.head shouldBe evDetail
     manager.containsAppId("test_app_id") shouldBe true
-    manager.getSource("test_app_id") shouldBe evSource
+    manager.getSourceDetail("test_app_id") shouldBe evDetail
   }
 
   it should "add the extra event sources as expected and remain in order" in {
-    val evSource1 = StubEventSource("test_app_id_1")
-    val evSource2 = StubEventSource("test_app_id_2")
-    val manager = new EventSourceManager(evSource2)
-    manager.addEventSource(evSource1)
+    val evDetail1 = stubEventDetails("test_app_id_1")
+    val evDetail2 = stubEventDetails("test_app_id_2")
+    val manager = new EventSourceManager(evDetail2)
+    manager.addEventSource(evDetail1)
 
     manager.sourceCount shouldEqual 2
-    manager.eventSources.toSet shouldBe Set(evSource1, evSource2)
+    manager.eventSource.toSet shouldBe Set(evDetail1, evDetail2)
     manager.containsAppId("test_app_id_1") shouldBe true
     manager.containsAppId("test_app_id_2") shouldBe true
-    manager.getSource("test_app_id_1") shouldBe evSource1
-    manager.getSource("test_app_id_2") shouldBe evSource2
+    manager.getSourceDetail("test_app_id_1") shouldBe evDetail1
+    manager.getSourceDetail("test_app_id_2") shouldBe evDetail2
   }
 
   it should "throw up when invalid appId specified for indexer" in {
-    val evSource = StubEventSource("test_app_id")
-    val manager = new EventSourceManager(evSource)
+    val evDetail = stubEventDetails("test_app_id")
+    val manager = new EventSourceManager(evDetail)
 
     intercept[NoSuchElementException] {
       manager.getSource("invalid_app_id")
     }
   }
-}
-
-
-case class StubEventSource(appId: String) extends EventSourceLike with FreeScrollEventSource {
-  override def version: String = ???
-
-  override def host: String = ???
-
-  override def port: Int = ???
-
-  override def maxMemory: Long = ???
-
-  override def appName: String = ???
-
-  override def user: String = ???
-
-  override def startTime: Long = ???
-
-  override def endTime: Long = ???
-
-  override def progress: EventSourceProgress = ???
-
-  override def state: SparklintStateLike = ???
-
-  override def fullName: String = ???
-
-  @throws[IllegalArgumentException]
-  override def forwardEvents(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def rewindEvents(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def forwardTasks(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def rewindTasks(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def forwardStages(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def rewindStages(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def forwardJobs(count: Int): EventSourceProgress = ???
-
-  @throws[IllegalArgumentException]
-  override def rewindJobs(count: Int): EventSourceProgress = ???
-
-  override def toEnd(): EventSourceProgress = ???
-
-  override def toStart(): EventSourceProgress = ???
 }

--- a/src/test/scala/com/groupon/sparklint/analyzer/EventSourceManagerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/analyzer/EventSourceManagerTest.scala
@@ -26,7 +26,7 @@ class EventSourceManagerTest extends FlatSpec with Matchers {
     val manager = new EventSourceManager()
 
     manager.sourceCount shouldEqual 0
-    manager.eventSource.isEmpty shouldBe true
+    manager.eventSources.isEmpty shouldBe true
   }
 
   it should "initialize with start state if initial sources supplied" in {
@@ -34,9 +34,9 @@ class EventSourceManagerTest extends FlatSpec with Matchers {
     val manager = new EventSourceManager(evDetail)
 
     manager.sourceCount shouldEqual 1
-    manager.eventSource.head shouldBe evDetail
+    manager.eventSources.head shouldBe evDetail
     manager.containsAppId("test_app_id") shouldBe true
-    manager.getSourceDetail("test_app_id") shouldBe evDetail
+    manager.getSource("test_app_id") shouldBe evDetail
   }
 
   it should "add the extra event sources as expected and remain in order" in {
@@ -46,11 +46,11 @@ class EventSourceManagerTest extends FlatSpec with Matchers {
     manager.addEventSource(evDetail1)
 
     manager.sourceCount shouldEqual 2
-    manager.eventSource.toSet shouldBe Set(evDetail1, evDetail2)
+    manager.eventSources.toSet shouldBe Set(evDetail1, evDetail2)
     manager.containsAppId("test_app_id_1") shouldBe true
     manager.containsAppId("test_app_id_2") shouldBe true
-    manager.getSourceDetail("test_app_id_1") shouldBe evDetail1
-    manager.getSourceDetail("test_app_id_2") shouldBe evDetail2
+    manager.getSource("test_app_id_1") shouldBe evDetail1
+    manager.getSource("test_app_id_2") shouldBe evDetail2
   }
 
   it should "throw up when invalid appId specified for indexer" in {

--- a/src/test/scala/com/groupon/sparklint/events/EventSourceProgressTest.scala
+++ b/src/test/scala/com/groupon/sparklint/events/EventSourceProgressTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class EventSourceProgressTest extends FlatSpec with Matchers {
 
   it should "default to empty progress trackers" in {
-    val progress = EventSourceProgress()
+    val progress = new EventSourceProgress()
 
     testProgress(progress.eventProgress, 0)
     testProgress(progress.taskProgress, 0)
@@ -33,7 +33,7 @@ class EventSourceProgressTest extends FlatSpec with Matchers {
   }
 
   it should "preprocess as expected" in {
-    val progress = EventSourceProgress()
+    val progress = new EventSourceProgress()
 
     progress.preprocess(sparkAppStart())
     testProgress(progress.eventProgress, 1)
@@ -79,7 +79,7 @@ class EventSourceProgressTest extends FlatSpec with Matchers {
   }
 
   it should "process on events as expected" in {
-    val progress = EventSourceProgress()
+    val progress = new EventSourceProgress()
 
     progress.onEvent(sparkAppStart())
     testProgress(progress.eventProgress, 1, 1)
@@ -135,7 +135,7 @@ class EventSourceProgressTest extends FlatSpec with Matchers {
   }
 
   it should "process un events as expected" in {
-    val progress = EventSourceProgress()
+    val progress = new EventSourceProgress()
 
     progress.onEvent(sparkAppStart())
     progress.onEvent(sparkJobStartFromId(0))
@@ -252,7 +252,7 @@ class EventProgressTest extends FlatSpec with Matchers {
   }
 
   it should "represent progress correctly" in {
-    val progress = EventProgress(10, 6, 4, Set("test-in-flight1", "test-in-flight2"))
+    val progress = new EventProgress(10, 6, 4, Set("test-in-flight1", "test-in-flight2"))
 
     progress.count shouldEqual 10
     progress.started shouldEqual 6
@@ -266,7 +266,7 @@ class EventProgressTest extends FlatSpec with Matchers {
   }
 
   it should "represent end of events correctly" in {
-    val progress = EventProgress(10, 10, 10, Set())
+    val progress = new EventProgress(10, 10, 10, Set())
 
     progress.count shouldEqual 10
     progress.started shouldEqual 10

--- a/src/test/scala/com/groupon/sparklint/events/EventSourceProgressTest.scala
+++ b/src/test/scala/com/groupon/sparklint/events/EventSourceProgressTest.scala
@@ -12,7 +12,10 @@
 */
 package com.groupon.sparklint.events
 
-import org.scalatest.{Matchers, FlatSpec}
+import com.groupon.sparklint.TestUtils._
+import com.groupon.sparklint.common.Utils
+import org.apache.spark.scheduler.TaskLocality
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author swhitear 
@@ -20,37 +23,260 @@ import org.scalatest.{Matchers, FlatSpec}
   */
 class EventSourceProgressTest extends FlatSpec with Matchers {
 
-  it should "throw up with invalid .ctor params" in {
-    intercept[IllegalArgumentException] {
-      EventSourceProgress(-1, 0)
-    }
-    intercept[IllegalArgumentException] {
-      EventSourceProgress(0, -1)
-    }
-    intercept[IllegalArgumentException] {
-      EventSourceProgress(10, 11)
-    }
+  it should "default to empty progress trackers" in {
+    val progress = EventSourceProgress()
+
+    testProgress(progress.eventProgress, 0)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
   }
 
-  it should "set start state correctly" in {
-    val progress = EventSourceProgress(10, 0)
-    progress.hasNext shouldBe true
-    progress.hasPrevious shouldBe false
-    progress.percent shouldEqual 0
+  it should "preprocess as expected" in {
+    val progress = EventSourceProgress()
+
+    progress.preprocess(sparkAppStart())
+    testProgress(progress.eventProgress, 1)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkTaskStartEventFromId(0))
+    testProgress(progress.eventProgress, 2)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkTaskEndEventFromId(0))
+    testProgress(progress.eventProgress, 3)
+    testProgress(progress.taskProgress, 1)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkStageSubmittedFromId(0))
+    testProgress(progress.eventProgress, 4)
+    testProgress(progress.taskProgress, 1)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkStageCompletedFromId(0))
+    testProgress(progress.eventProgress, 5)
+    testProgress(progress.taskProgress, 1)
+    testProgress(progress.stageProgress, 1)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkJobStartFromId(0))
+    testProgress(progress.eventProgress, 6)
+    testProgress(progress.taskProgress, 1)
+    testProgress(progress.stageProgress, 1)
+    testProgress(progress.jobProgress, 0)
+
+    progress.preprocess(sparkJobEndFromId(0))
+    testProgress(progress.eventProgress, 7)
+    testProgress(progress.taskProgress, 1)
+    testProgress(progress.stageProgress, 1)
+    testProgress(progress.jobProgress, 1)
   }
 
-  it should "set end state correctly" in {
-    val progress = EventSourceProgress(10, 10)
-    progress.hasNext shouldBe false
-    progress.hasPrevious shouldBe true
-    progress.percent shouldEqual 100
+  it should "process on events as expected" in {
+    val progress = EventSourceProgress()
+
+    progress.onEvent(sparkAppStart())
+    testProgress(progress.eventProgress, 1, 1)
+    testProgress(progress.taskProgress, 0, 0)
+    testProgress(progress.stageProgress, 0, 0)
+    testProgress(progress.jobProgress, 0, 0)
+
+    progress.onEvent(sparkJobStartFromId(0))
+    testProgress(progress.eventProgress, 2, 2)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    val stageInfo = sparkStageInfo(stageId = 0, name = "test-stage-name")
+    progress.onEvent(sparkStageSubmitted(stageInfo))
+    testProgress(progress.eventProgress, 3, 3)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    val taskInfo1 = sparkTaskInfo(taskId = 1, host = "host1")
+    val taskInfo2 = sparkTaskInfo(taskId = 2, host = "host2")
+    progress.onEvent(sparkTaskStartEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    progress.onEvent(sparkTaskStartEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    testProgress(progress.eventProgress, 5, 5)
+    testProgress(progress.taskProgress, 2, 0, taskName(1, "host1"), taskName(2, "host2"))
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.onEvent(sparkTaskEndEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    testProgress(progress.eventProgress, 6, 6)
+    testProgress(progress.taskProgress, 2, 1, taskName(2, "host2"))
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.onEvent(sparkTaskEndEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    testProgress(progress.eventProgress, 7, 7)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.onEvent(sparkStageCompleted(stageInfo))
+    testProgress(progress.eventProgress, 8, 8)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 1)
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.onEvent(sparkJobEndFromId(0))
+    testProgress(progress.eventProgress, 9, 9)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 1)
+    testProgress(progress.jobProgress, 1, 1)
   }
 
-  it should "set mid state correctly" in {
-    val progress = EventSourceProgress(10, 4)
-    progress.hasNext shouldBe true
-    progress.hasPrevious shouldBe true
-    progress.percent shouldEqual 40
+  it should "process un events as expected" in {
+    val progress = EventSourceProgress()
+
+    progress.onEvent(sparkAppStart())
+    progress.onEvent(sparkJobStartFromId(0))
+    val stageInfo = sparkStageInfo(stageId = 0, name = "test-stage-name")
+    progress.onEvent(sparkStageSubmitted(stageInfo))
+    val taskInfo1 = sparkTaskInfo(taskId = 1, host = "host1")
+    val taskInfo2 = sparkTaskInfo(taskId = 2, host = "host2")
+    progress.onEvent(sparkTaskStartEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    progress.onEvent(sparkTaskStartEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    progress.onEvent(sparkTaskEndEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    progress.onEvent(sparkTaskEndEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    progress.onEvent(sparkStageCompleted(stageInfo))
+    progress.onEvent(sparkJobEndFromId(0))
+    testProgress(progress.eventProgress, 9, 9)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 1)
+    testProgress(progress.jobProgress, 1, 1)
+
+    progress.unEvent(sparkJobEndFromId(0))
+    testProgress(progress.eventProgress, 8, 8)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 1)
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkStageCompleted(stageInfo))
+    testProgress(progress.eventProgress, 7, 7)
+    testProgress(progress.taskProgress, 2, 2)
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkTaskEndEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    testProgress(progress.eventProgress, 6, 6)
+    testProgress(progress.taskProgress, 2, 1, taskName(2, "host2"))
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkTaskEndEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    testProgress(progress.eventProgress, 5, 5)
+    testProgress(progress.taskProgress, 2, 0, taskName(1, "host1"), taskName(2, "host2"))
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkTaskStartEvent(taskId = taskInfo2.taskId)(taskInfo = taskInfo2))
+    testProgress(progress.eventProgress, 4, 4)
+    testProgress(progress.taskProgress, 1, 0, taskName(1, "host1"))
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkTaskStartEvent(taskId = taskInfo1.taskId)(taskInfo = taskInfo1))
+    testProgress(progress.eventProgress, 3, 3)
+    testProgress(progress.taskProgress, 0, 0)
+    testProgress(progress.stageProgress, 1, 0, "test-stage-name")
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkStageSubmitted(stageInfo))
+    testProgress(progress.eventProgress, 2, 2)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 1, 0, jobName(0))
+
+    progress.unEvent(sparkJobStartFromId(0))
+    testProgress(progress.eventProgress, 1, 1)
+    testProgress(progress.taskProgress, 0, 0)
+    testProgress(progress.stageProgress, 0, 0)
+    testProgress(progress.jobProgress, 0, 0)
+
+    progress.unEvent(sparkAppStart())
+    testProgress(progress.eventProgress, 0)
+    testProgress(progress.taskProgress, 0)
+    testProgress(progress.stageProgress, 0)
+    testProgress(progress.jobProgress, 0)
+  }
+
+
+  private def testProgress(progress: EventProgressLike, count: Int,
+                           started: Int, complete: Int, active: String*): Unit = {
+    progress.count shouldEqual count
+    progress.started shouldEqual started
+    progress.complete shouldEqual complete
+    progress.active shouldEqual active.toSet
+  }
+
+  private def testProgress(progress: EventProgressLike, count: Int): Unit = {
+    testProgress(progress, count, 0, 0)
+  }
+
+  private def testProgress(progress: EventProgressLike, started: Int, complete: Int, active: String*): Unit = {
+    testProgress(progress, 0, started, complete, active:_*)
+  }
+
+  private def taskName(taskId: Int, host: String, attemptId: Int = 0) = {
+    s"ID$taskId:${TaskLocality.NO_PREF}:$host(attempt $attemptId)"
+  }
+
+  private def jobName(jobId: Int) = {
+    s"ID$jobId:${Utils.UNKNOWN_STRING}"
+  }
+}
+
+class EventProgressTest extends FlatSpec with Matchers {
+
+  it should "empty sets zero values" in {
+    val progress = EventProgress.empty()
+
+    progress.count shouldEqual 0
+    progress.started shouldEqual 0
+    progress.complete shouldEqual 0
+    progress.inFlightCount shouldEqual 0
+    progress.active shouldEqual Set.empty[String]
+    progress.percent shouldEqual 0d
+    progress.hasNext shouldEqual false
+    progress.hasPrevious shouldEqual false
+    progress.description shouldEqual "Completed 0 / 0 (0%) with 0 active."
+  }
+
+  it should "represent progress correctly" in {
+    val progress = EventProgress(10, 6, 4, Set("test-in-flight1", "test-in-flight2"))
+
+    progress.count shouldEqual 10
+    progress.started shouldEqual 6
+    progress.complete shouldEqual 4
+    progress.inFlightCount shouldEqual 2
+    progress.active shouldEqual Set("test-in-flight1", "test-in-flight2")
+    progress.percent shouldEqual 40d
+    progress.hasNext shouldEqual true
+    progress.hasPrevious shouldEqual true
+    progress.description shouldEqual "Completed 4 / 10 (40%) with 2 active (test-in-flight1, test-in-flight2)."
+  }
+
+  it should "represent end of events correctly" in {
+    val progress = EventProgress(10, 10, 10, Set())
+
+    progress.count shouldEqual 10
+    progress.started shouldEqual 10
+    progress.complete shouldEqual 10
+    progress.inFlightCount shouldEqual 0
+    progress.active shouldEqual Set()
+    progress.percent shouldEqual 100d
+    progress.hasNext shouldEqual false
+    progress.hasPrevious shouldEqual true
+    progress.description shouldEqual "Completed 10 / 10 (100%) with 0 active."
   }
 
 }

--- a/src/test/scala/com/groupon/sparklint/events/FileEventSourceTest.scala
+++ b/src/test/scala/com/groupon/sparklint/events/FileEventSourceTest.scala
@@ -4,30 +4,32 @@ import java.io.File
 
 import com.groupon.sparklint.TestUtils.resource
 import com.groupon.sparklint.common.Utils
-import com.groupon.sparklint.data.SparklintStateLike
-import com.groupon.sparklint.data.compressed.CompressedState
 import org.apache.spark.groupon.StringToSparkEvent
 import org.apache.spark.scheduler._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
-import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 
 /**
   * @author swhitear 
   * @since 9/14/16.
   */
-class FileEventSourceTest extends FlatSpec with Matchers {
+class FileEventSourceTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+
+  var receiver: StubEventReceiver = _
+
+  override protected def beforeEach(): Unit = {
+    receiver = new StubEventReceiver()
+  }
 
   it should "throw up if the file does not exist" in {
     intercept[IllegalArgumentException] {
-      FileEventSource(new File("wherefore/art/though/filey"), StubEventState())
+      FileEventSource(new File("wherefore/art/though/filey"), Seq(receiver))
     }
   }
 
   it should "throw up if negative scroll count used" in {
-    val state = new LosslessEventState()
-    val source = FileEventSource(testFileWithState, state)
+    val source = FileEventSource(testFileWithState, Seq(receiver))
 
     intercept[IllegalArgumentException] {
       source.forwardEvents(count = -1)
@@ -38,29 +40,29 @@ class FileEventSourceTest extends FlatSpec with Matchers {
   }
 
   it should "handle an empty file just fine" in {
-    val state = StubEventState()
-    val source = FileEventSource(emptyFile, state)
+    val source = FileEventSource(emptyFile, Seq(receiver))
 
     source.appId shouldEqual "file_event_log_empty_test"
     source.appName shouldEqual Utils.UNKNOWN_STRING
     source.nameOrId shouldEqual "file_event_log_empty_test"
 
-    state.onEvents.isEmpty shouldEqual true
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe false
-    source.progress.hasPrevious shouldBe false
+    receiver.eventCount shouldEqual 0
+    source.hasNext shouldBe false
+    source.hasPrevious shouldBe false
 
     source.forwardEvents()
-    state.onEvents.isEmpty shouldEqual true
-    state.unEvents.isEmpty shouldEqual true
+    receiver.eventCount shouldEqual 0
+    source.hasNext shouldBe false
+    source.hasPrevious shouldBe false
+
     source.rewindEvents()
-    state.onEvents.isEmpty shouldEqual true
-    state.unEvents.isEmpty shouldEqual true
+    receiver.eventCount shouldEqual 0
+    source.hasNext shouldBe false
+    source.hasPrevious shouldBe false
   }
 
   it should "set initial state if events in source" in {
-    val state = new LosslessEventState()
-    val source = FileEventSource(testFileWithState, state)
+    val source = FileEventSource(testFileWithState, Seq(receiver))
 
     source.version shouldEqual "1.5.2"
     source.appId shouldEqual "application_1462781278026_205691"
@@ -76,149 +78,167 @@ class FileEventSourceTest extends FlatSpec with Matchers {
     source.endTime shouldEqual 0
   }
 
-  it should "allow two way iteration through file content" in {
-    val state = StubEventState()
+  it should "preprocess the source events" in {
     val fileEvents = testEvents(testFileNoState)
-    val source = FileEventSource(testFileNoState, state)
+    val source = FileEventSource(testFileNoState, Seq(receiver))
 
     source.appId shouldEqual "file_event_log_test_simple"
-    state.onEvents.size shouldEqual 0
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.eventCount shouldEqual 5
+    receiver.preprocCount shouldEqual 5
+    receiver.onCount shouldEqual 0
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
+    testIdsMatchForRange(receiver.preprocEvents, fileEvents, 0 to 4)
+  }
+
+  it should "allow two way iteration through file content" in {
+    val fileEvents = testEvents(testFileNoState)
+    val source = FileEventSource(testFileNoState, Seq(receiver))
+
+    source.appId shouldEqual "file_event_log_test_simple"
+    receiver.eventCount shouldEqual 5
+    receiver.preprocCount shouldEqual 5
+    receiver.onCount shouldEqual 0
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
 
     source.forwardEvents(count = 5)
-    state.onEvents.size shouldEqual 5
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 4)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe false
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 5
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 4)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe false
+    source.hasPrevious shouldBe true
 
     source.rewindEvents(count = 5)
-    state.onEvents.size shouldEqual 5
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 4)
-    state.unEvents.size shouldEqual 5
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 4, 4 to 0 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.onCount shouldEqual 5
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 4)
+    receiver.unCount shouldEqual 5
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 4, 4 to 0 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
   }
 
   it should "allow two way task iteration through file content" in {
-    val state = StubEventState()
     val fileEvents = testEvents(testFileWithNavEvents)
-    val source = FileEventSource(testFileWithNavEvents, state)
+    val source = FileEventSource(testFileWithNavEvents, Seq(receiver))
 
     source.appId shouldEqual "file_event_log_test_nav_events"
-    state.onEvents.size shouldEqual 0
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.eventCount shouldEqual 16
+    receiver.preprocCount shouldEqual 16
+    receiver.onCount shouldEqual 0
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
 
     source.forwardTasks()
-    state.onEvents.size shouldEqual 4
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 3)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 4
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 3)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.forwardTasks(count = 2)
-    state.onEvents.size shouldEqual 14
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 13)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 14
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 13)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.rewindTasks()
-    state.onEvents.size shouldEqual 14
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 13)
-    state.unEvents.size shouldEqual 2
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 1, 13 to 12 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 14
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 13)
+    receiver.unCount shouldEqual 2
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 1, 13 to 12 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.rewindTasks(count = 2)
-    state.onEvents.size shouldEqual 14
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 13)
-    state.unEvents.size shouldEqual 12
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 11, 13 to 3 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 14
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 13)
+    receiver.unCount shouldEqual 12
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 11, 13 to 3 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
   }
 
   it should "allow two way stage iteration through file content" in {
-    val state = StubEventState()
     val fileEvents = testEvents(testFileWithNavEvents)
-    val source = FileEventSource(testFileWithNavEvents, state)
+    val source = FileEventSource(testFileWithNavEvents, Seq(receiver))
 
     source.appId shouldEqual "file_event_log_test_nav_events"
-    state.onEvents.size shouldEqual 0
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.eventCount shouldEqual 16
+    receiver.preprocCount shouldEqual 16
+    receiver.onCount shouldEqual 0
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
 
     source.forwardStages()
-    state.onEvents.size shouldEqual 5
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 4)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 5
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 4)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.forwardStages(count = 2)
-    state.onEvents.size shouldEqual 15
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 14)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 15
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 14)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.rewindStages()
-    state.onEvents.size shouldEqual 15
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 14)
-    state.unEvents.size shouldEqual 4
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 3, 14 to 11 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 15
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 14)
+    receiver.unCount shouldEqual 4
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 3, 14 to 11 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.rewindStages(count = 2)
-    state.onEvents.size shouldEqual 15
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 14)
-    state.unEvents.size shouldEqual 14
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 13, 14 to 2 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 15
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 14)
+    receiver.unCount shouldEqual 14
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 13, 14 to 2 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
   }
 
   it should "allow two way job iteration through file content" in {
-    val state = StubEventState()
     val fileEvents = testEvents(testFileWithNavEvents)
-    val source = FileEventSource(testFileWithNavEvents, state)
+    val source = FileEventSource(testFileWithNavEvents, Seq(receiver))
 
     source.appId shouldEqual "file_event_log_test_nav_events"
-    state.onEvents.size shouldEqual 0
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.eventCount shouldEqual 16
+    receiver.preprocCount shouldEqual 16
+    receiver.onCount shouldEqual 0
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
 
     source.forwardJobs()
-    state.onEvents.size shouldEqual 6
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 5)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 6
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 5)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe true
 
     source.forwardJobs()
-    state.onEvents.size shouldEqual 16
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 15)
-    state.unEvents.isEmpty shouldEqual true
-    source.progress.hasNext shouldBe false
-    source.progress.hasPrevious shouldBe true
+    receiver.onCount shouldEqual 16
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 15)
+    receiver.unCount shouldEqual 0
+    source.hasNext shouldBe false
+    source.hasPrevious shouldBe true
 
     source.rewindJobs(count = 2)
-    state.onEvents.size shouldEqual 16
-    testIdsMatchForRange(state.onEvents, fileEvents, 0 to 15)
-    state.unEvents.size shouldEqual 16
-    testIdsMatchForRange(state.unEvents, fileEvents, 0 to 15, 15 to 0 by -1)
-    source.progress.hasNext shouldBe true
-    source.progress.hasPrevious shouldBe false
+    receiver.onCount shouldEqual 16
+    testIdsMatchForRange(receiver.onEvents, fileEvents, 0 to 15)
+    receiver.unCount shouldEqual 16
+    testIdsMatchForRange(receiver.unEvents, fileEvents, 0 to 15, 15 to 0 by -1)
+    source.hasNext shouldBe true
+    source.hasPrevious shouldBe false
   }
 
   private def testFileNoState: File = {
@@ -245,6 +265,7 @@ class FileEventSourceTest extends FlatSpec with Matchers {
                                    seq: Seq[Int]): Unit = {
     testIdsMatchForRange(test, expected, seq, seq)
   }
+
   private def testIdsMatchForRange(test: Seq[SparkListenerEvent], expected: Seq[SparkListenerEvent],
                                    testSeq: Seq[Int], expectedSeq: Seq[Int]): Unit = {
     testSeq.zip(expectedSeq).foreach(pair => testIdsMatch(test(pair._1), expected(pair._2)))
@@ -261,14 +282,4 @@ class FileEventSourceTest extends FlatSpec with Matchers {
   }
 }
 
-private case class StubEventState(onEvents: ArrayBuffer[SparkListenerEvent] = ArrayBuffer.empty,
-                                  unEvents: ArrayBuffer[SparkListenerEvent] = ArrayBuffer.empty,
-                                  state: SparklintStateLike = CompressedState.empty)
-  extends EventStateLike {
 
-  override def onEvent(event: SparkListenerEvent): Unit = onEvents += event
-
-  override def unEvent(event: SparkListenerEvent): Unit = unEvents += event
-
-  override def getState: SparklintStateLike = state
-}

--- a/src/test/scala/com/groupon/sparklint/events/StubEventReceiver.scala
+++ b/src/test/scala/com/groupon/sparklint/events/StubEventReceiver.scala
@@ -1,0 +1,111 @@
+package com.groupon.sparklint.events
+
+import org.apache.spark.scheduler._
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Routes all events to a list based on their process type (preproc, on, un).
+  *
+  * @author swhitear 
+  * @since 11/16/16.
+  */
+class StubEventReceiver() extends EventReceiverLike {
+
+  val preprocEvents = ArrayBuffer.empty[SparkListenerEvent]
+  val onEvents      = ArrayBuffer.empty[SparkListenerEvent]
+  val unEvents      = ArrayBuffer.empty[SparkListenerEvent]
+
+  def eventCount = preprocEvents.size + onEvents.size + unEvents.size
+  def preprocCount = preprocEvents.size
+  def onCount = onEvents.size
+  def unCount = unEvents.size
+
+  override def preprocAddApp(event: SparkListenerApplicationStart): Unit = appendPreproc(event)
+
+  override def preprocAddExecutor(event: SparkListenerExecutorAdded): Unit = appendPreproc(event)
+
+  override def preprocRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = appendPreproc(event)
+
+  override def preprocAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = appendPreproc(event)
+
+  override def preprocJobStart(event: SparkListenerJobStart): Unit = appendPreproc(event)
+
+  override def preprocStageSubmitted(event: SparkListenerStageSubmitted): Unit = appendPreproc(event)
+
+  override def preprocTaskStart(event: SparkListenerTaskStart): Unit = appendPreproc(event)
+
+  override def preprocTaskEnd(event: SparkListenerTaskEnd): Unit = appendPreproc(event)
+
+  override def preprocStageCompleted(event: SparkListenerStageCompleted): Unit = appendPreproc(event)
+
+  override def preprocJobEnd(event: SparkListenerJobEnd): Unit = appendPreproc(event)
+
+  override def preprocUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = appendPreproc(event)
+
+  override def preprocEndApp(event: SparkListenerApplicationEnd): Unit = appendPreproc(event)
+
+  override def addApp(event: SparkListenerApplicationStart): Unit = appendOn(event)
+
+  override def addExecutor(event: SparkListenerExecutorAdded): Unit = appendOn(event)
+
+  override def removeExecutor(event: SparkListenerExecutorRemoved): Unit = appendOn(event)
+
+  override def addBlockManager(event: SparkListenerBlockManagerAdded): Unit = appendOn(event)
+
+  override def jobStart(event: SparkListenerJobStart): Unit = appendOn(event)
+
+  override def stageSubmitted(event: SparkListenerStageSubmitted): Unit = appendOn(event)
+
+  override def taskStart(event: SparkListenerTaskStart): Unit = appendOn(event)
+
+  override def taskEnd(event: SparkListenerTaskEnd): Unit = appendOn(event)
+
+  override def stageCompleted(event: SparkListenerStageCompleted): Unit = appendOn(event)
+
+  override def jobEnd(event: SparkListenerJobEnd): Unit = appendOn(event)
+
+  override def unpersistRDD(event: SparkListenerUnpersistRDD): Unit = appendOn(event)
+
+  override def endApp(event: SparkListenerApplicationEnd): Unit = appendUn(event)
+
+  override def unAddApp(event: SparkListenerApplicationStart): Unit = appendUn(event)
+
+  override def unAddExecutor(event: SparkListenerExecutorAdded): Unit = appendUn(event)
+
+  override def unRemoveExecutor(event: SparkListenerExecutorRemoved): Unit = appendUn(event)
+
+  override def unAddBlockManager(event: SparkListenerBlockManagerAdded): Unit = appendUn(event)
+
+  override def unJobStart(event: SparkListenerJobStart): Unit = appendUn(event)
+
+  override def unStageSubmitted(event: SparkListenerStageSubmitted): Unit = appendUn(event)
+
+  override def unTaskStart(event: SparkListenerTaskStart): Unit = appendUn(event)
+
+  override def unTaskEnd(event: SparkListenerTaskEnd): Unit = appendUn(event)
+
+  override def unStageCompleted(event: SparkListenerStageCompleted): Unit = appendUn(event)
+
+  override def unJobEnd(event: SparkListenerJobEnd): Unit = appendUn(event)
+
+  override def unUnpersistRDD(event: SparkListenerUnpersistRDD): Unit = appendUn(event)
+
+  override def unEndApp(event: SparkListenerApplicationEnd): Unit = appendUn(event)
+
+
+  private def appendPreproc(event: SparkListenerEvent) = preprocEvents += event
+
+  private def appendOn(event: SparkListenerEvent) =  onEvents += event
+
+  private def appendUn(event: SparkListenerEvent) =  unEvents += event
+
+}
+
+abstract class ProcType(procType: String)
+
+case class Preproc() extends ProcType("preprocess")
+
+case class On() extends ProcType("on")
+
+case class Un() extends ProcType("un")

--- a/src/test/scala/com/groupon/sparklint/events/StubEventSource.scala
+++ b/src/test/scala/com/groupon/sparklint/events/StubEventSource.scala
@@ -1,0 +1,58 @@
+package com.groupon.sparklint.events
+
+/**
+  *
+  * @author swhitear 
+  * @since 11/16/16.
+  */
+case class StubEventSource(appId: String) extends EventSourceLike with FreeScrollEventSource {
+  override def version: String = ???
+
+  override def host: String = ???
+
+  override def port: Int = ???
+
+  override def maxMemory: Long = ???
+
+  override def appName: String = ???
+
+  override def user: String = ???
+
+  override def startTime: Long = ???
+
+  override def endTime: Long = ???
+
+  override def fullName: String = ???
+
+  @throws[IllegalArgumentException]
+  override def forwardEvents(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def rewindEvents(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def forwardTasks(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def rewindTasks(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def forwardStages(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def rewindStages(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def forwardJobs(count: Int): Unit = ???
+
+  @throws[IllegalArgumentException]
+  override def rewindJobs(count: Int): Unit = ???
+
+  override def toEnd(): Unit = ???
+
+  override def toStart(): Unit = ???
+
+  override def hasNext: Boolean = ???
+
+  override def hasPrevious: Boolean = ???
+}

--- a/src/test/scala/com/groupon/sparklint/events/StubEventState.scala
+++ b/src/test/scala/com/groupon/sparklint/events/StubEventState.scala
@@ -1,0 +1,24 @@
+package com.groupon.sparklint.events
+
+import com.groupon.sparklint.data.SparklintStateLike
+import com.groupon.sparklint.data.compressed.CompressedState
+import org.apache.spark.scheduler.SparkListenerEvent
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  *
+  * @author swhitear 
+  * @since 11/16/16.
+  */
+case class StubEventState(onEvents: ArrayBuffer[SparkListenerEvent] = ArrayBuffer.empty,
+                          unEvents: ArrayBuffer[SparkListenerEvent] = ArrayBuffer.empty,
+                          state: SparklintStateLike = CompressedState.empty)
+  extends EventStateLike {
+
+  override def onEvent(event: SparkListenerEvent): Unit = onEvents += event
+
+  override def unEvent(event: SparkListenerEvent): Unit = unEvents += event
+
+  override def getState: SparklintStateLike = state
+}

--- a/src/test/scala/com/groupon/sparklint/ui/UIServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/ui/UIServerTest.scala
@@ -27,19 +27,18 @@ import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
   */
 class UIServerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
   var evSource       : EventSourceLike with FreeScrollEventSource     = _
-  var evState        : EventStateLike with EventReceiverLike          = _
+  var evState        : EventStateLike                                 = _
   var progress       : EventSourceProgressLike with EventReceiverLike = _
   var evSourceManager: EventSourceManagerLike                         = _
   var server         : UIServer                                       = _
 
   override protected def beforeEach(): Unit = {
     val file = new File(TestUtils.resource("spark_event_log_example"))
-    progress = EventSourceProgress()
+    progress = new EventSourceProgress()
     evState = new CompressedEventState(30)
-    evSource = new FileEventSource(file, Seq(progress, evState))
+    evSource = FileEventSource(file, Seq(progress, evState))
     evSourceManager = new EventSourceManager()
-    evSourceManager.addEventSource(EventSourceDetail(evSource, progress, evState))
-
+    evSourceManager.addEventSource(EventSourceDetail(evSource, evState, progress))
     server = new UIServer(evSourceManager)
     server.startServer(Some(42424))
   }
@@ -527,7 +526,6 @@ class UIServerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   private def state: JValue = {
     parse(request(stateUrl))
-    //UIServer.reportJson(SparklintStateAnalyzer(evSource, evState), evSource, progress)
   }
 
   private def forward(count: Int): String = {


### PR DESCRIPTION
This PR started as an attempt to track the progress of events, tasks, stages and jobs for display in the top bar.  During those changes I realized we were too reliant on the coupling between an EventSource and the EventState it produces.  I decided to rethink the way an EventSource publishes events and use a simple Seq of a new EventReceiverLike trait to allow multiple, different implementing classes to handle events independently.

In this PR I have included the core refactoring, the new EventReceiverLike trait that acts like a default handler and router for EventSource events, a new EventSourceProgress class that extends EventReceiverLike and handles all the progress reporting, and a refactor of both Compressed and Lossless EventState instances to also become EventReceiver's.

Also tightened up the UIServer class around request handling and internal errors.  Made UIServer tests use the endpoints to ensure proper test coverage of that class.
