### PR TITLE
Make port a part of sparklingConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Please note, in the jar the `161` means `Spark1.6.1` and `2.10` means `scala 2.1
 
 If your spark version is not precompiled (i.e. 1.5.0), you can add an entry in `project/BuildUtils.getSparkMajorVersion`, then provide compatible code similar to spark-1.6 in `src/main/spark-1.5`
 
+For more detail about event logging, how to enable it, and how to gather log files, check http://spark.apache.org/docs/latest/configuration.html#spark-ui
+
 ##### Live mode (run inside spark driver node)
 
 SparklintListener is an implementation of [SparkFirehoseListener](https://spark.apache.org/docs/1.5.2/api/java/org/apache/spark/SparkFirehoseListener.html)
@@ -62,15 +64,16 @@ You can feed Sparklint an event log file to playback activities.
 - Docker support is comming soon, track progress at #26
 - Spark version doesn't matter in server mode
 
-The command line arguments supported are:
-
-- `-f [FileName]`: Filename of an Spark event log source to use.
-- `-d [DirectoryName]`: Directory of an Spark event log sources to use. Read in filename sort order.
-- `-p [pollRate]`: The interval (in seconds) between polling for changes in directory and history event sources.
-- `-r`: Set the flag in order to run each buffer through to their end state on startup.
-
-
-For more detail about event logging, how to enable it, and how to gather log files, check http://spark.apache.org/docs/latest/configuration.html#spark-ui
+### Config
+* Common config
+    * Set the port of the UI (eg, 4242)
+        - In live mode, send `--conf sparklint.port=4242` to spark submit script
+        - In server mode, send `--port 4242` to sbt run commandline argument
+* Server only config
+    - `-f [FileName]`: Filename of an Spark event log source to use.
+    - `-d [DirectoryName]`: Directory of an Spark event log sources to use. Read in filename sort order.
+    - `-p [pollRate]`: The interval (in seconds) between polling for changes in directory and history event sources.
+    - `-r`: Set the flag in order to run each buffer through to their end state on startup.
 
 ### Developer cheatsheet
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ startYear := Some(2016)
 licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 // Compile
+enablePlugins(AutomateHeaderPlugin)
 name:= s"sparklint-spark${BuildUtils.getProjectNameSuffix(sparkVersion.value)}"
 scalaVersion := "2.10.6"
 crossScalaVersions := Seq("2.10.6", "2.11.8")

--- a/src/main/scala/com/groupon/sparklint/SparklintListener.scala
+++ b/src/main/scala/com/groupon/sparklint/SparklintListener.scala
@@ -16,6 +16,7 @@
 
 package com.groupon.sparklint
 
+import com.groupon.sparklint.common.{SparkConfSparklintConfig, SparklintConfig}
 import com.groupon.sparklint.events._
 import com.groupon.sparklint.ui.UIServer
 import org.apache.spark.scheduler.SparkListenerEvent
@@ -27,10 +28,10 @@ import org.apache.spark.{SparkConf, SparkFirehoseListener}
   * @author rxue
   * @since 8/18/16.
   */
-class SparklintListener(appId: String, appName: String) extends SparkFirehoseListener {
+class SparklintListener(appId: String, appName: String, config: SparklintConfig) extends SparkFirehoseListener {
 
   def this(conf: SparkConf) = {
-    this(conf.get("spark.app.id", "AppId"), conf.get("spark.app.name", "AppName"))
+    this(conf.get("spark.app.id", "AppId"), conf.get("spark.app.name", "AppName"), new SparkConfSparklintConfig(conf))
   }
 
   override def onEvent(event: SparkListenerEvent): Unit = {
@@ -46,7 +47,7 @@ class SparklintListener(appId: String, appName: String) extends SparkFirehoseLis
 
   val detail = SourceAndDetail(buffer, EventSourceDetail(appId, meta, progress, stateManager))
   val eventSourceManager = new EventSourceManager(detail)
-  val uiServer = new UIServer(eventSourceManager)
+  val uiServer = new UIServer(eventSourceManager, config)
 
   // ATTN: ordering?
   uiServer.startServer()

--- a/src/main/scala/com/groupon/sparklint/SparklintServer.scala
+++ b/src/main/scala/com/groupon/sparklint/SparklintServer.scala
@@ -30,7 +30,7 @@ import scala.concurrent.{Await, Future, Promise}
   */
 class SparklintServer(eventSourceManager: FileEventSourceManager,
                       scheduler: SchedulerLike,
-                      config: SparklintConfig)
+                      config: CliSparklintConfig)
   extends Logging {
 
   implicit val logger: Logging = this
@@ -46,7 +46,7 @@ class SparklintServer(eventSourceManager: FileEventSourceManager,
   def startUI(): Unit = {
     shutdownUI()
     // wire up the front end server using the analyzer to adapt state via models
-    val uiServer = new UIServer(eventSourceManager)
+    val uiServer = new UIServer(eventSourceManager, config)
     ui = Some(uiServer)
     uiServer.startServer()
   }
@@ -93,7 +93,7 @@ object SparklintServer extends Logging with OptParse {
   def main(args: Array[String]): Unit = {
     val eventSourceManager = new FileEventSourceManager()
     val scheduler = new Scheduler()
-    val config = SparklintConfig().parseCliArgs(args)
+    val config = CliSparklintConfig().parseCliArgs(args)
     val server = new SparklintServer(eventSourceManager, scheduler, config)
     server.startUI()
     waitForever

--- a/src/main/scala/com/groupon/sparklint/common/CliSparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/CliSparklintConfig.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Groupon, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.groupon.sparklint.common
+
+import java.io.File
+
+import com.frugalmechanic.optparse.OptParse
+
+/**
+  * A simple wrapper around some build time specific configuration properties.
+  *
+  * @author rxue, swhitear
+  * @since 9/12/16.
+  */
+case class CliSparklintConfig(exitOnError: Boolean = true) extends SparklintConfig
+  with OptParse with Logging {
+  // For testing we want OptParse to throw exceptions instead of calling System.exit
+  override val optParseExitOnError: Boolean = exitOnError
+
+
+  override def port: Int = portConfig.getOrElse(defaultPort)
+
+  val portConfig = IntOpt(
+    long = "port",
+    desc = "Set the port for sparklint UI to launch"
+  )
+
+  val fileSource = FileOpt(
+    long = "file", short = 'f',
+    desc = "Filename of an Spark event log source to use."
+  )
+
+  val directorySource = FileOpt(
+    long = "directory", short = 'd',
+    desc = "Directory of an Spark event log sources to use. Read in filename sort order.",
+    validate = (input: File) => input.isDirectory
+  )
+
+  val runImmediately = BoolOpt(
+    long = "runImmediately", short = 'r',
+    desc = "Set the flag in order to run each buffer through to their end state on startup."
+  )
+
+  val historySource = StrOpt(desc = "Url of the Spark History Server to use.")
+
+  val pollRate = IntOpt(
+    long = "pollRate", short = 'p',
+    desc = "The interval (in seconds) between polling for changes in directory and history event sources.",
+    validate = (value) => value > 0
+  )
+
+  /**
+    *
+    * @param args the command line arguments
+    * @return the config built
+    */
+  def parseCliArgs(args: Array[String]): CliSparklintConfig = {
+    logInfo(s"Parsing args: ${args.mkString(" ")}")
+    parse(args)
+    logInfo(s"Parsed into: ${foundOpts.map(o => s"${o.long.get}").mkString(", ")}")
+    this
+  }
+}

--- a/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
@@ -1,0 +1,11 @@
+package com.groupon.sparklint.common
+
+import org.apache.spark.SparkConf
+
+/**
+  * @author rxue
+  * @since 12/7/16.
+  */
+class SparkConfSparklintConfig(conf: SparkConf) extends SparklintConfig {
+  override def port: Int = conf.get("sparklint.port", defaultPort.toString).toInt
+}

--- a/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Groupon, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.groupon.sparklint.common
 
 import org.apache.spark.SparkConf

--- a/src/main/scala/com/groupon/sparklint/common/SparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/SparklintConfig.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Groupon, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.groupon.sparklint.common
 
 /**

--- a/src/main/scala/com/groupon/sparklint/common/SparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/SparklintConfig.scala
@@ -1,70 +1,11 @@
-/*
- * Copyright 2016 Groupon, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.groupon.sparklint.common
 
-import java.io.File
-
-import com.frugalmechanic.optparse.OptParse
-
 /**
-  * A simple wrapper around some build time specific configuration properties.
-  *
-  * @author rxue, swhitear
-  * @since 9/12/16.
+  * @author rxue
+  * @since 12/7/16.
   */
-case class SparklintConfig(exitOnError: Boolean = true) extends OptParse with Logging {
-  // For testing we want OptParse to throw exceptions instead of calling System.exit
-  override val optParseExitOnError: Boolean = exitOnError
+trait SparklintConfig {
+  def port: Int
+  val defaultPort = 23763
 
-  val fileSource = FileOpt(
-    long = "file", short = 'f',
-    desc = "Filename of an Spark event log source to use."
-  )
-
-  val directorySource = FileOpt(
-    long = "directory", short = 'd',
-    desc = "Directory of an Spark event log sources to use. Read in filename sort order.",
-    validate = (input: File) => input.isDirectory
-  )
-
-  val runImmediately = BoolOpt(
-    long = "runImmediately", short = 'r',
-    desc = "Set the flag in order to run each buffer through to their end state on startup."
-  )
-
-  val historySource = StrOpt(desc = "Url of the Spark History Server to use.")
-
-  val pollRate = IntOpt(
-    long = "pollRate", short = 'p',
-    desc = "The interval (in seconds) between polling for changes in directory and history event sources.",
-    validate = (value) => value > 0
-  )
-
-  /**
-    *
-    * @param args the command line arguments
-    * @return the config built
-    */
-  def parseCliArgs(args: Array[String]): SparklintConfig = {
-    logInfo(s"Parsing args: ${args.mkString(" ")}")
-    parse(args)
-    logInfo(s"Parsed into: ${foundOpts.map(o => s"${o.long.get}").mkString(", ")}")
-    this
-  }
-
-  // TODO: We need to support SparkConf based configuration as well to allow SparklintListener config this object
 }

--- a/src/main/scala/com/groupon/sparklint/server/AdhocServer.scala
+++ b/src/main/scala/com/groupon/sparklint/server/AdhocServer.scala
@@ -40,7 +40,7 @@ import scalaz.concurrent.Task
   * @since 4/25/16.
   */
 trait AdhocServer extends RoutingMap with Logging {
-  val DEFAULT_PORT           = 23763
+  def DEFAULT_PORT: Int
   // Random number without special meaning
   var server: Option[Server] = None
 

--- a/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
+++ b/src/main/scala/com/groupon/sparklint/ui/UIServer.scala
@@ -17,11 +17,11 @@
 package com.groupon.sparklint.ui
 
 import com.groupon.sparklint.analyzer.SparklintStateAnalyzer
-import com.groupon.sparklint.common.Logging
+import com.groupon.sparklint.common.{Logging, SparklintConfig}
 import com.groupon.sparklint.events._
 import com.groupon.sparklint.server.{AdhocServer, StaticFileService}
-import org.http4s.{HttpService, Response}
 import org.http4s.dsl._
+import org.http4s.{HttpService, Response}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{DefaultFormats, Extraction, JObject}
@@ -34,10 +34,12 @@ import scalaz.concurrent.Task
   * @author swhitear
   * @since 8/18/16.
   */
-class UIServer(esManager: EventSourceManagerLike)
+class UIServer(esManager: EventSourceManagerLike, config: SparklintConfig)
   extends AdhocServer with StaticFileService with Logging {
 
   routingMap("/") = sparklintService
+
+  override def DEFAULT_PORT: Int = config.port
 
   private def sparklintService = HttpService {
     case GET -> Root                                                            => tryit(homepage, htmlResponse)
@@ -85,6 +87,7 @@ class UIServer(esManager: EventSourceManagerLike)
 
   private def fwdApp(appId: String, count: String, evType: EventType): String = {
     def progress() = esManager.getSourceDetail(appId).progress
+
     val mover = moveEventSource(count, appId, progress) _
     val eventSource = esManager.getScrollingSource(appId)
     evType match {
@@ -101,6 +104,7 @@ class UIServer(esManager: EventSourceManagerLike)
 
   private def rwdApp(appId: String, count: String, evType: EventType): String = {
     def progress() = esManager.getSourceDetail(appId).progress
+
     val mover = moveEventSource(count, appId, progress) _
     val eventSource = esManager.getScrollingSource(appId)
     evType match {

--- a/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/SparklintServerTest.scala
@@ -14,7 +14,7 @@ package com.groupon.sparklint
 
 import java.io.File
 
-import com.groupon.sparklint.common.{ScheduledTask, SchedulerLike, SparklintConfig}
+import com.groupon.sparklint.common.{ScheduledTask, SchedulerLike, CliSparklintConfig}
 import com.groupon.sparklint.common.TestUtils._
 import com.groupon.sparklint.events.FileEventSourceManager
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
@@ -35,14 +35,14 @@ class SparklintServerTest extends FlatSpec with BeforeAndAfterEach with Matchers
   private var dirname           : String                 = _
   private var tempFile          : File                   = _
   private var scheduler         : StubScheduler          = _
-  private var config            : SparklintConfig        = _
+  private var config            : CliSparklintConfig = _
 
   override protected def beforeEach(): Unit = {
     eventSourceManager = new FileEventSourceManager()
     scheduler = new StubScheduler()
     dirname = resource("directory_source")
     tempFile = resetTempFile(dirname)
-    config = SparklintConfig(exitOnError = false)
+    config = CliSparklintConfig(exitOnError = false)
     server = new SparklintServer(eventSourceManager, scheduler, config)
   }
 

--- a/src/test/scala/com/groupon/sparklint/server/AdhocServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/server/AdhocServerTest.scala
@@ -91,6 +91,9 @@ class AdhocServerTest extends FlatSpec with BeforeAndAfterAll with Matchers {
   }
 
   def getService = new AdhocServer with HeartBeatService {
+
+    override def DEFAULT_PORT: Int = 40000
+
     val secret = 4242
 
     routingMap("") = HttpService {

--- a/src/test/scala/com/groupon/sparklint/ui/UIServerTest.scala
+++ b/src/test/scala/com/groupon/sparklint/ui/UIServerTest.scala
@@ -14,7 +14,7 @@ package com.groupon.sparklint.ui
 
 import java.io.File
 
-import com.groupon.sparklint.common.TestUtils
+import com.groupon.sparklint.common.{SparklintConfig, TestUtils}
 import com.groupon.sparklint.events.{CompressedStateManager, FileEventSourceManager}
 import org.http4s.client.blaze.PooledHttp1Client
 import org.json4s.JValue
@@ -37,7 +37,10 @@ class UIServerTest extends FlatSpec with Matchers with BeforeAndAfterEach {
     }
 
     evSourceManager.addFile(file)
-    server = new UIServer(evSourceManager)
+    val config = new SparklintConfig {
+      override def port: Int = defaultPort
+    }
+    server = new UIServer(evSourceManager, config)
     server.startServer(Some(42424))
   }
 


### PR DESCRIPTION
Now we can set the port of the UI (eg, 4242)

- In live mode, send `--conf sparklint.port=4242` to spark submit script
- In server mode, send `--port 4242` to sbt run commandline argument

Fixes #41 as well