### PR TITLE
Docker fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ You can feed Sparklint an event log file to playback activities.
 ##### Server mode (docker)
 - Docker support available at https://hub.docker.com/r/roboxue/sparklint/
 - pull docker image from docker hub or build locally with `sbt docker`
-- Execute the docker image: `docker run -p 23736:23763 roboxue/sparklint && open localhost:23763`
+- Execute the docker image: 
+  - `docker run -v /path/to/logs/dir:/logs -p 23763:23763 roboxue/sparklint -d /logs && open localhost:23763`
+  - `docker run -v /path/to/logs/file:/logfile -p 23763:23763 roboxue/sparklint -f /logfile && open localhost:23763`
 
 
 ### Config

--- a/build.sbt
+++ b/build.sbt
@@ -39,11 +39,11 @@ resolvers in ThisBuild ++= Seq(
   Resolver.sonatypeRepo("releases")
 )
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
+  "org.apache.spark" %% "spark-core" % sparkVersion.value
     exclude("com.fasterxml.jackson.module", "*"),
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
+  "org.apache.spark" %% "spark-sql" % sparkVersion.value
     exclude("com.fasterxml.jackson.module", "*"),
-  "org.apache.spark" %% "spark-streaming" % sparkVersion.value % "provided"
+  "org.apache.spark" %% "spark-streaming" % sparkVersion.value
     exclude("com.fasterxml.jackson.module", "*"),
   "com.frugalmechanic" %% "scala-optparse" % optparse,
   "org.http4s" %% "http4s-dsl" % http4s,


### PR DESCRIPTION
Remove "provided" on spark dependency, which is the reason why docker build is missing spark dependencies

Fixes #59 