### PR TITLE
Fix custom port for live mode (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can feed Sparklint an event log file to playback activities.
 ### Config
 * Common config
     * Set the port of the UI (eg, 4242)
-        - In live mode, send `--conf sparklint.port=4242` to spark submit script
+        - In live mode, send `--conf spark.sparklint.port=4242` to spark submit script
         - In server mode, send `--port 4242` to sbt run commandline argument
 * Server only config
     - `-f [FileName]`: Filename of an Spark event log source to use.

--- a/src/main/scala/com/groupon/sparklint/SparklintListener.scala
+++ b/src/main/scala/com/groupon/sparklint/SparklintListener.scala
@@ -47,5 +47,5 @@ class SparklintListener(appId: String, appName: String, config: SparklintConfig)
   esgm.registerEventSource(liveEventSource)
   sparklint.backend.append(esgm)
   Future(liveEventSource.start())
-  sparklint.startServer()
+  sparklint.startServer(Some(config.port))
 }

--- a/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
+++ b/src/main/scala/com/groupon/sparklint/common/SparkConfSparklintConfig.scala
@@ -23,5 +23,5 @@ import org.apache.spark.SparkConf
   * @since 12/7/16.
   */
 class SparkConfSparklintConfig(conf: SparkConf) extends SparklintConfig {
-  override def port: Int = conf.get("sparklint.port", defaultPort.toString).toInt
+  override def port: Int = conf.get("spark.sparklint.port", defaultPort.toString).toInt
 }


### PR DESCRIPTION
This will start Sparklint on the custom port when used in live mode (spark listener in Driver).  This also modifies the spark config to include "spark." at the beginning so it can be applied on the spark cli.