### PR TITLE
Detect if app is served over HTTPS and adjust WS protocol accordingly

### DIFF
--- a/src/main/resources/js/sparklintHomepage.js
+++ b/src/main/resources/js/sparklintHomepage.js
@@ -17,7 +17,8 @@ function loadApp(esmId, appId) {
     if (eventSocketStream !== undefined) {
         eventSocketStream.close();
     }
-    eventSocketStream = new WebSocket("ws://" + window.location.host + "/backend/esm/" + esmId + "/" + appId + "/stateWS");
+    var protocol = window.location.protocol == "https:" ? "wss:" : "ws:"
+    eventSocketStream = new WebSocket(protocol+"//" + window.location.host + "/backend/esm/" + esmId + "/" + appId + "/stateWS");
     eventSocketStream.addEventListener('message', function (statePayload) {
         var data = JSON.parse(statePayload.data);
         displayAppState(appId, data);


### PR DESCRIPTION
When sparklint is exposed through a proxy using HTTPS, modern navigators refuse a direct WS connection and require WSS.

This patch adds a protocol detection test to handle this case when building WebSocket URL.